### PR TITLE
Fix for poco library

### DIFF
--- a/build_library_with_toolchain.sh
+++ b/build_library_with_toolchain.sh
@@ -25,12 +25,13 @@ echo
 [ "$CMAKE_PREFIX_PATH" = "" ] && die 'could not find target basedir. Have you run build_catkin.sh and sourced setup.bash?'
 
 if [ ! -d toolchain/ ]; then
-  $ANDROID_NDK/build/tools/make-standalone-toolchain.sh --install-dir=./toolchain --arch=arm64
+  $ANDROID_NDK/build/tools/make-standalone-toolchain.sh --install-dir=./toolchain --arch=$arch
 fi
 export PATH=$PATH:$2/toolchain/bin
 
 if [ $1 == 'poco' ]; then
     ./configure --config=Android_static --no-samples --no-tests
+    export ANDROID_ABI=$abi
 elif [ $1 == 'curl' ]; then
     ./configure --prefix=$CMAKE_PREFIX_PATH --disable-shared --enable-static --without-ssl --host=arm-linux-androideabi --disable-tftp --disable-sspi --disable-ipv6 --disable-ldaps --disable-ldap --disable-telnet --disable-pop3 --disable-ftp --disable-imap --disable-smtp --disable-pop3 --disable-rtsp --disable-ares --without-ca-bundle --disable-warnings --disable-manual --without-nss --without-random
 else
@@ -42,7 +43,7 @@ make -s -j$PARALLEL_JOBS -l$PARALLEL_JOBS
 if [ $1 == 'poco' ]; then
     mkdir -p $CMAKE_PREFIX_PATH/lib
     cd $CMAKE_PREFIX_PATH/lib
-    cp $prefix/lib/Android/armeabi/lib*.a ./
+    cp $prefix/lib/Android/$abi/lib*.a ./
     mkdir -p ../include && cd ../include
     cp -r $prefix/Foundation/include/Poco ./
 else

--- a/config.sh
+++ b/config.sh
@@ -1,6 +1,13 @@
 system=$(uname -s | tr 'DL' 'dl')-$(uname -m)
 toolchain=llvm
 abi=arm64-v8a
+
+if [ "armeabi-v7a" = $abi ]; then
+    arch="arm"
+elif [ "arm64-v8a" = $abi ]; then
+    arch="arm64"
+fi
+
 platform=android-24
 PYTHONPATH=/opt/ros/kinetic/lib/python2.7/dist-packages:$PYTHONPATH
 # Enable this value for debug build
@@ -9,4 +16,3 @@ CMAKE_BUILD_TYPE=Release
 # Enable this if you need to use pluginlib in Android.
 # The plugins will be statically linked
 use_pluginlib=1
-

--- a/patches/poco.patch
+++ b/patches/poco.patch
@@ -161,17 +161,17 @@
 +# General Settings
 +#
 +LINKMODE           ?= STATIC
-+ANDROID_ABI        ?= armeabi
++ANDROID_ABI        ?= arm64-v8a
 +POCO_TARGET_OSNAME  = Android
 +POCO_TARGET_OSARCH  = $(ANDROID_ABI)
 +
-+ifeq ($(ANDROID_ABI),armeabi)
++ifeq ($(ANDROID_ABI),arm64-v8a)
 +TOOL      = aarch64-linux-android
-+ARCHFLAGS = -mthumb
++# ARCHFLAGS = 
 +else
 +ifeq ($(ANDROID_ABI),armeabi-v7a)
-+TOOL      = aarch64-linux-android
-+ARCHFLAGS = -march=armv7-a -mfloat-abi=softfp
++TOOL      = arm-linux-androideabi
++ARCHFLAGS = -mthumb
 +LINKFLAGS = -Wl,--fix-cortex-a8
 +else
 +ifeq ($(ANDROID_ABI),x86)

--- a/patches/poco.patch
+++ b/patches/poco.patch
@@ -166,11 +166,11 @@
 +POCO_TARGET_OSARCH  = $(ANDROID_ABI)
 +
 +ifeq ($(ANDROID_ABI),armeabi)
-+TOOL      = arm-linux-androideabi
++TOOL      = aarch64-linux-android
 +ARCHFLAGS = -mthumb
 +else
 +ifeq ($(ANDROID_ABI),armeabi-v7a)
-+TOOL      = arm-linux-androideabi
++TOOL      = aarch64-linux-android
 +ARCHFLAGS = -march=armv7-a -mfloat-abi=softfp
 +LINKFLAGS = -Wl,--fix-cortex-a8
 +else
@@ -186,15 +186,15 @@
 +#
 +# Define Tools
 +#
-+CC      = $(TOOL)-gcc
-+CXX     = $(TOOL)-g++
++CC      = $(TOOL)-clang
++CXX     = $(TOOL)-clang++
 +LINK    = $(CXX)
 +STRIP   = $(TOOL)-strip
 +LIB     = $(TOOL)-ar -cr
 +RANLIB  = $(TOOL)-ranlib
 +SHLIB   = $(CXX) -shared -Wl,-soname,$(notdir $@) -o $@
 +SHLIBLN = $(POCO_BASE)/build/script/shlibln
-+DEP     = $(POCO_BASE)/build/script/makedepend.gcc
++DEP     = $(POCO_BASE)/build/script/makedepend.clang
 +SHELL   = sh
 +RM      = rm -rf
 +CP      = cp


### PR DESCRIPTION
This fix allows compiling `libpoco` with `clang` instead of `gcc`.