### PR TITLE
Docker update

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -290,8 +290,8 @@ if [ $use_pluginlib -ne 0 ]; then
     echo
 
     # Install Python libraries that are needed by the scripts
-    sudo apt-get install python-lxml -y
-    sudo rosdep init || true
+    apt-get install python-lxml -y
+    rosdep init || true
     rosdep update
     pluginlib_helper_file=pluginlib_helper.cpp
     $my_loc/files/pluginlib_helper/pluginlib_helper.py -scanroot $prefix/catkin_ws/src -cppout $my_loc/files/pluginlib_helper/$pluginlib_helper_file

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,35 +1,35 @@
-FROM ubuntu:14.04
-MAINTAINER Julian Cerruti <jcerruti@creativa77.com.ar>
-MAINTAINER Gary Servin <gary@creativa77.com.ar>
+FROM ros:kinetic-ros-base-xenial
+MAINTAINER Julian Cerruti <jcerruti@ekumenlabs.com>
+MAINTAINER Gary Servin <gary@ekumenlabs.com>
+MAINTAINER Juan Ignacio Ubeira <jubeira@ekumenlabs.com>
 
-# Install ROS Indigo
+# Install basic tools
 RUN apt-get update && apt-get install -y wget git unzip
-RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
-RUN wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
-RUN apt-get update && apt-get install --no-install-recommends -y ros-indigo-ros-base python-wstool
 
 # Install Android NDK
-RUN wget http://dl.google.com/android/ndk/android-ndk-r8e-linux-x86_64.tar.bz2
-RUN tar -jxvf android-ndk-r8e-linux-x86_64.tar.bz2 -C /opt
+WORKDIR /opt/android/sdk
+RUN wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
+RUN unzip android-ndk-r18b-linux-x86_64.zip -d /opt/android/sdk
 
 # Set-up environment
-ENV ANDROID_NDK /opt/android-ndk-r8e
+ENV ANDROID_NDK /opt/android/sdk/android-ndk-r18b
 
 # Install g++ to avoid "CMAKE_CXX_COMPILER-NOTFOUND was not found." error
-RUN apt-get update && apt-get install -y g++ cmake make
+RUN apt-get update && apt-get install -y g++ cmake make clang
 
 # Install Android SDK
-RUN apt-get update && apt-get install -y openjdk-6-jdk lib32z1 lib32ncurses5 lib32bz2-1.0 lib32stdc++6 ant
-RUN wget http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz
-RUN tar -xvf android-sdk_r23.0.2-linux.tgz -C /opt
-ENV PATH /opt/android-sdk-linux/tools:/opt/android-sdk-linux/platform-tools:$PATH
-ENV ANDROID_HOME /opt/android-sdk-linux
-RUN (while true; do echo 'y'; sleep 2; done) | android update sdk -u -t 2,3,7,8,9,11,13,16,56,57
+ENV ANDROID_HOME /opt/android/sdk
+RUN apt-get update && apt-get install -y openjdk-8-jdk
+RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
+RUN unzip sdk-tools-linux-4333796.zip -d /opt/android/sdk
+RUN yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
+RUN $ANDROID_HOME/tools/bin/sdkmanager "build-tools;26.0.2" "platform-tools" "platforms;android-26" --sdk_root=/opt/android/sdk
+ENV PATH /opt/android/sdk/tools:/opt/android/sdk/platform-tools:$PATH
 
 # Install Python libraries
 RUN apt-get install python-lxml -y
 
-ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64/
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 # Use ccache
 RUN apt-get update && apt-get install -y ccache

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,7 @@
+# android_ndk docker image
+
+This image contains all the basic tools required to cross compile the ROS packages and its dependencies.
+
+To build the image, run `build.sh`. To run the image, run `run.sh`. `ros_android` folder and all its contents will be mapped to `/opt/ros_android` inside the docker container. 
+
+Once inside the container, place the output in a child directory of `/opt/ros_android` to be able to access it from your host computer.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+IMAGE=android_ndk
+
+pushd "$( dirname "${BASH_SOURCE[0]}" )"
+docker build -t ${IMAGE} .
+popd

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+OUTPUT_DIR=$SCRIPTPATH/../
+IMAGE=android_ndk
+
+if [ "$#" == 0 ]; then
+  EXTRA_ARGS="bash"
+else
+  EXTRA_ARGS="bash -c \"$@\""
+fi
+
+#mkdir -p $OUTPUT_DIR
+docker run \
+  -v ${OUTPUT_DIR}:/opt/ros_android \
+  --privileged \
+  -it \
+  ${IMAGE} "${EXTRA_ARGS}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-OUTPUT_DIR=$SCRIPTPATH/../
+REPO_ROOT=$SCRIPTPATH/../
 IMAGE=android_ndk
 
 if [ "$#" == 0 ]; then
@@ -10,9 +10,8 @@ else
   EXTRA_ARGS="bash -c \"$@\""
 fi
 
-#mkdir -p $OUTPUT_DIR
 docker run \
-  -v ${OUTPUT_DIR}:/opt/ros_android \
+  -v ${REPO_ROOT}:/opt/ros_android \
   --privileged \
   -it \
   ${IMAGE} "${EXTRA_ARGS}"


### PR DESCRIPTION
This is a first draft of the docker image update.

As the cross compilation scripts copy output libraries to `/opt/ros/kinetic`, it's preferable to continue with the development in a container so as not to pollute host systems and eliminate sources of error among different computers.

In the future perhaps we can remove ROS completely from the image and clean it up a bit more (e.g. `clang`, `gcc`, etc); as of now it's not a priority.

/cc @meyerj @ivanpauno