### PR TITLE
Fix opencv linker errors

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -245,9 +245,8 @@ if [[ $skip -ne 1 ]] ; then
     # https://source.android.com/reference/com/android/tradefed/testtype/GTest.html
     # apply_patch $my_loc/patches/camera_info_manager.patch
 
-    # Patch cv_bridge - remove Python dependencies
-    # TODO: https://github.com/ros-perception/vision_opencv/pull/55 merged, need to wait until new version (current 1.11.7)
-    # apply_patch $my_loc/patches/cv_bridge.patch
+    # Patch cv_bridge - fix transitive linking in cv_bridge-extras.cmake
+    apply_patch $my_loc/patches/cv_bridge.patch
 
     # Patch robot_pose_ekf - Add bfl library cmake variables, also, remove tests
     # TODO: The correct way to handle this would be to create .cmake files for bfl and do a findpackage(orocos-bfl)

--- a/patches/cv_bridge.patch
+++ b/patches/cv_bridge.patch
@@ -1,39 +1,34 @@
---- catkin_ws/src/vision_opencv/cv_bridge/CMakeLists.txt	2014-12-16 13:23:41.106085276 -0300
-+++ catkin_ws/src/vision_opencv/cv_bridge/CMakeLists.txt	2014-12-16 13:25:29.358088880 -0300
-@@ -3,7 +3,11 @@
+--- catkin_ws/src/vision_opencv/cv_bridge/CMakeLists.txt
++++ catkin_ws/src/vision_opencv/cv_bridge/CMakeLists.txt
+@@ -25,7 +25,6 @@ catkin_package(
+   INCLUDE_DIRS include
+   LIBRARIES ${PROJECT_NAME}
+   CATKIN_DEPENDS rosconsole sensor_msgs
+-  DEPENDS OpenCV
+   CFG_EXTRAS cv_bridge-extras.cmake
+ )
  
- find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
+--- catkin_ws/src/vision_opencv/cv_bridge/cmake/cv_bridge-extras.cmake.in
++++ catkin_ws/src/vision_opencv/cv_bridge/cmake/cv_bridge-extras.cmake.in
+@@ -1,12 +1,7 @@
+-set(OpenCV_VERSION @OpenCV_VERSION@)
+-set(OpenCV_VERSION_MAJOR @OpenCV_VERSION_MAJOR@)
+-set(OpenCV_VERSION_MINOR @OpenCV_VERSION_MINOR@)
+-set(OpenCV_VERSION_PATCH @OpenCV_VERSION_PATCH@)
+-set(OpenCV_SHARED @OpenCV_SHARED@)
+-set(OpenCV_CONFIG_PATH @OpenCV_CONFIG_PATH@)
+-set(OpenCV_INSTALL_PATH @OpenCV_INSTALL_PATH@)
+-set(OpenCV_LIB_COMPONENTS @OpenCV_LIB_COMPONENTS@)
+-set(OpenCV_USE_MANGLED_PATHS @OpenCV_USE_MANGLED_PATHS@)
+-set(OpenCV_MODULES_SUFFIX @OpenCV_MODULES_SUFFIX@)
+-
++find_package(OpenCV 3 REQUIRED
++  COMPONENTS
++    opencv_core
++    opencv_imgproc
++    opencv_imgcodecs
++  CONFIG
++)
  
-+if(NOT ANDROID)
- find_package(Boost REQUIRED python)
-+else()
-+find_package(Boost REQUIRED)
-+endif()
- find_package(OpenCV REQUIRED)
- if (OpenCV_VERSION VERSION_EQUAL "3")
-   add_definitions("-DOPENCV3=1")
-@@ -21,7 +25,9 @@
- include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
- include_directories(include ${catkin_INCLUDE_DIRS})
- 
-+if(NOT ANDROID)
- add_subdirectory(python)
-+endif()
- add_subdirectory(src)
- if(CATKIN_ENABLE_TESTING)
-   add_subdirectory(test)
---- catkin_ws/src/vision_opencv/cv_bridge/src/CMakeLists.txt	2014-12-12 14:16:26.261088783 -0300
-+++ catkin_ws/src/vision_opencv/cv_bridge/src/CMakeLists.txt	2014-12-12 14:17:17.117087617 -0300
-@@ -5,6 +5,7 @@
- 
- install(TARGETS ${PROJECT_NAME} DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
- 
-+if(NOT ANDROID)
- # add a Boost Python library
- find_package(PythonInterp REQUIRED)
- find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
-@@ -54,3 +55,4 @@
- endif()
- 
- install(TARGETS ${PROJECT_NAME}_boost DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}/boost/)
-+endif()
++list(APPEND @PROJECT_NAME@_LIBRARIES ${OpenCV_LIBRARIES})
++list(APPEND @PROJECT_NAME@_INCLUDE_DIRS ${OpenCV_INCLUDE_DIRS})

--- a/patches/opencv.patch
+++ b/patches/opencv.patch
@@ -88,3 +88,17 @@
  
  # ----------------------------------------------------------------------------
  # Finalization: generate configuration-based files
+@@ -850,11 +845,11 @@
+ if(ANDROID OR NOT UNIX)
+   install(FILES ${OPENCV_LICENSE_FILE}
+         PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
+-        DESTINATION ./ COMPONENT libs)
++        DESTINATION ${OPENCV_OTHER_INSTALL_PATH} COMPONENT libs)
+   if(OPENCV_README_FILE)
+     install(FILES ${OPENCV_README_FILE}
+             PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
+-            DESTINATION ./ COMPONENT libs)
++            DESTINATION ${OPENCV_OTHER_INSTALL_PATH} COMPONENT libs)
+   endif()
+ endif()
+ 


### PR DESCRIPTION
This patch was needed to not only add the `libopencv*.a` libraries to `cv_bridge_LIBRARIES`, but also all their transitive link dependencies. I got linker errors when creating executables that only link with `cv_bridge` but not to OpenCV libraries.

The patch calls `find_package(OpenCV 3)` in `cv_bridge-extras.cmake.in` again to find the libraries using the OpenCV cmake module configuration and then adds the targets to `cv_bridge_LIBRARIES` instead of the resolved library names. CMake knows their implicit link dependency from the [`INTERFACE_LINK_LIBRARIES` target properties](https://cmake.org/cmake/help/v3.0/prop_tgt/INTERFACE_LINK_LIBRARIES.html). Linking to library files instead of imported targets is almost always wrong and causes linker errors for static libraries.

The second patch is only to make sure that OpenCV's `README.android` and `LICENSE` are not installed in the root of the target dir.