### PR TITLE
Remove catkin from libs

### DIFF
--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -101,7 +101,7 @@ export ROS_PARALLEL_JOBS="-j$PARALLEL_JOBS -l$PARALLEL_JOBS"
 # export ROS_PARALLEL_JOBS="-j1"
 
 catkin config \
-  --extend $prefix/target \
+  --no-extend \
   --install-space $prefix/target \
   --install \
   --isolate-devel \

--- a/build_library.sh
+++ b/build_library.sh
@@ -19,10 +19,7 @@ echo
 
 cmake_build $2
 
-if [ $1 == 'catkin' ]; then
-    echo 'done. please run the following:'
-    echo "  . $target/setup.bash"
-elif [ $1 == 'eigen' ]; then
+if [ $1 == 'eigen' ]; then
 	cp -r $CMAKE_PREFIX_PATH/include/eigen3/* $CMAKE_PREFIX_PATH/include
 fi
 

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -118,7 +118,6 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/poco-1.8.0 ] || run_cmd get_library poco $prefix/libs
 [ -d $prefix/libs/tinyxml ] || run_cmd get_library tinyxml $prefix/libs
 [ -d $prefix/libs/tinyxml2 ] || run_cmd get_library tinyxml2 $prefix/libs
-[ -d $prefix/libs/catkin ] || run_cmd get_library catkin $prefix/libs
 [ -d $prefix/libs/console_bridge ] || run_cmd get_library console_bridge $prefix/libs
 [ -d $prefix/libs/lz4-r124 ] || run_cmd get_library lz4 $prefix/libs
 [ -d $prefix/libs/curl-7.39.0 ] || run_cmd get_library curl $prefix/libs
@@ -142,9 +141,6 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/pcrecpp ] || run_cmd get_library pcrecpp $prefix/libs
 # get rospkg dependency for pluginlib support at build time
 [ -d $my_loc/files/rospkg ] || run_cmd get_library rospkg $my_loc/files
-
-[ -f $prefix/target/bin/catkin_make ] || run_cmd build_library catkin $prefix/libs/catkin
-. $prefix/target/setup.bash
 
 echo
 echo -e '\e[34mGetting ROS packages\e[39m'

--- a/get_library.sh
+++ b/get_library.sh
@@ -31,9 +31,6 @@ elif [ $1 == 'boost' ]; then
 elif [ $1 == 'bzip2' ]; then
     URL=https://github.com/osrf/bzip2_cmake.git
     COMP='git'
-elif [ $1 == 'catkin' ]; then
-    URL='-b 0.6.5 https://github.com/ros/catkin.git'
-    COMP='git'
 elif [ $1 == 'collada_dom' ]; then
     URL=http://ufpr.dl.sourceforge.net/project/collada-dom/Collada%20DOM/Collada%20DOM%202.4/collada-dom-2.4.0.tgz
     COMP='gz'


### PR DESCRIPTION
`catkin_tools` (#14) automatically finds and uses `catkin` in the source-space of `catkin_ws`. No need to pre-install.