### PR TITLE
Update console_bridge, urdfdom_headers, urdfdom and collada_dom

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -126,7 +126,7 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/urdfdom_headers ] || run_cmd get_library urdfdom_headers $prefix/libs
 [ -d $prefix/libs/libiconv-1.14 ] || run_cmd get_library libiconv $prefix/libs
 [ -d $prefix/libs/libxml2-2.9.1 ] || run_cmd get_library libxml2 $prefix/libs
-[ -d $prefix/libs/collada-dom-2.4.0 ] || run_cmd get_library collada_dom $prefix/libs
+[ -d $prefix/libs/collada_dom ] || run_cmd get_library collada_dom $prefix/libs
 [ -d $prefix/libs/eigen-3.3.5 ] || run_cmd get_library eigen $prefix/libs
 [ -d $prefix/libs/assimp-3.1.1 ] || run_cmd get_library assimp $prefix/libs
 [ -d $prefix/libs/qhull-2015.2 ] || run_cmd get_library qhull $prefix/libs
@@ -165,6 +165,9 @@ if [[ $skip -ne 1 ]] ; then
 
     #  Patch assimp - Build as static lib
     apply_patch $my_loc/patches/assimp.patch
+
+    # Patch console_bridge - Disable unit tests (unsatisfied dependencies)
+    apply_patch $my_loc/patches/console_bridge.patch
 
     # Patch urdfdom - Build as static lib
     apply_patch $my_loc/patches/urdfdom.patch
@@ -344,7 +347,7 @@ echo
 [ -f $prefix/target/lib/liburdfdom_model.a ] || run_cmd build_library urdfdom $prefix/libs/urdfdom
 [ -f $prefix/target/lib/libiconv.a ] || run_cmd build_library_with_toolchain libiconv $prefix/libs/libiconv-1.14
 [ -f $prefix/target/lib/libxml2.a ] || run_cmd build_library_with_toolchain libxml2 $prefix/libs/libxml2-2.9.1
-[ -f $prefix/target/lib/libcollada-dom2.4-dp.a ] || run_cmd build_library collada_dom $prefix/libs/collada-dom-2.4.0
+[ -f $prefix/target/lib/libcollada-dom2.4-dp.a ] || run_cmd build_library collada_dom $prefix/libs/collada_dom
 [ -f $prefix/target/lib/libassimp.a ] || run_cmd build_library assimp $prefix/libs/assimp-3.1.1
 [ -f $prefix/target/lib/libeigen.a ] || run_cmd build_library eigen $prefix/libs/eigen-3.3.5
 [ -f $prefix/target/lib/libqhullstatic.a ] || run_cmd build_library qhull $prefix/libs/qhull-2015.2

--- a/get_library.sh
+++ b/get_library.sh
@@ -35,12 +35,13 @@ elif [ $1 == 'catkin' ]; then
     URL='-b 0.6.5 https://github.com/ros/catkin.git'
     COMP='git'
 elif [ $1 == 'collada_dom' ]; then
-    URL=http://ufpr.dl.sourceforge.net/project/collada-dom/Collada%20DOM/Collada%20DOM%202.4/collada-dom-2.4.0.tgz
-    COMP='gz'
+    URL=https://github.com/rdiankov/collada-dom.git
+    COMP='git'
+    HASH='v2.4.4'
 elif [ $1 == 'console_bridge' ]; then
     URL=https://github.com/ros/console_bridge.git
     COMP='git'
-    HASH='964a9a70e0fc607476e439b8947a36b07322c304'
+    HASH='0.3.2'
 elif [ $1 == 'curl' ]; then
     URL=http://curl.haxx.se/download/curl-7.39.0.tar.bz2
     COMP='bz2'
@@ -95,11 +96,11 @@ elif [ $1   == 'tinyxml2' ]; then
 elif [ $1 == 'urdfdom_headers' ]; then
     URL=https://github.com/ros/urdfdom_headers.git
     COMP='git'
-    HASH='9aed7256e06d62935966de2a9bc9ddfac96e7a85'
+    HASH='0.4.2'
 elif [ $1 == 'urdfdom' ]; then
     URL=https://github.com/ros/urdfdom.git
     COMP='git'
-    HASH='c4ac03caf55369c64c61605b78f1b6071bb4acce'
+    HASH='0.4.2'
 elif [ $1 == 'uuid' ]; then
     URL=https://github.com/chadrockey/uuid_cmake
     COMP='git'

--- a/patches/collada_dom.patch
+++ b/patches/collada_dom.patch
@@ -1,5 +1,5 @@
---- libs/collada-dom-2.4.0/CMakeLists.txt
-+++ libs/collada-dom-2.4.0/CMakeLists.txt
+--- libs/collada_dom/CMakeLists.txt
++++ libs/collada_dom/CMakeLists.txt
 @@ -109,6 +109,8 @@ include(CheckCXXSourceCompiles)
  include(CheckTypeSize)
  find_package(PkgConfig)
@@ -10,8 +10,8 @@
    add_definitions("-fno-strict-aliasing -Wall")
  endif()
 
---- libs/collada-dom-2.4.0/dom/CMakeLists.txt
-+++ libs/collada-dom-2.4.0/dom/CMakeLists.txt
+--- libs/collada_dom/dom/CMakeLists.txt
++++ libs/collada_dom/dom/CMakeLists.txt
 @@ -27,7 +27,7 @@ if( OPT_COLLADA14 )
    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/1.4 DESTINATION ${COLLADA_DOM_INCLUDE_INSTALL_DIR} COMPONENT ${COMPONENT_PREFIX}-dev  PATTERN ".svn" EXCLUDE PATTERN ".~" EXCLUDE)
  endif()
@@ -22,8 +22,8 @@
  set_target_properties(collada-dom PROPERTIES
    COMPILE_FLAGS "${COLLADA_COMPILE_FLAGS}"
 
---- libs/collada-dom-2.4.0/dom/external-libs/pcre-8.02/pcrecpp.cc
-+++ libs/collada-dom-2.4.0/dom/external-libs/pcre-8.02/pcrecpp.cc
+--- libs/collada_dom/dom/external-libs/pcre-8.02/pcrecpp.cc
++++ libs/collada_dom/dom/external-libs/pcre-8.02/pcrecpp.cc
 @@ -47,6 +47,7 @@
  #include "pcrecpp.h"
  #include "pcre_stringpiece.h"

--- a/patches/console_bridge.patch
+++ b/patches/console_bridge.patch
@@ -1,0 +1,12 @@
+--- libs/console_bridge/CMakeLists.txt
++++ libs/console_bridge/CMakeLists.txt
+@@ -89,5 +89,7 @@ SET_DIRECTORY_PROPERTIES(PROPERTIES
+   ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_BINARY_DIR}/console_bridge-config.cmake
+   ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_BINARY_DIR}/console_bridge.pc)
+ 
+-enable_testing()
+-add_subdirectory(test)
++if(NOT ANDROID)
++  enable_testing()
++  add_subdirectory(test)
++endif()

--- a/patches/urdfdom.patch
+++ b/patches/urdfdom.patch
@@ -1,25 +1,66 @@
---- libs/urdfdom/urdf_parser/CMakeLists.txt	2014-11-13 18:42:30.721044671 -0300
-+++ libs/urdfdom/urdf_parser/CMakeLists.txt	2014-11-13 18:38:03.475500828 -0300
-@@ -1,18 +1,18 @@
+--- libs/urdfdom/urdf_parser/CMakeLists.txt
++++ libs/urdfdom/urdf_parser/CMakeLists.txt
+@@ -1,42 +1,46 @@
  include_directories(include)
  
 -add_library(urdfdom_world SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp src/world.cpp)
 +add_library(urdfdom_world src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp src/world.cpp)
- target_link_libraries(urdfdom_world ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
- set_target_properties(urdfdom_world PROPERTIES SOVERSION 0.3)
+ target_link_libraries(urdfdom_world ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
+ set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
  
 -add_library(urdfdom_model SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
 +add_library(urdfdom_model src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
- target_link_libraries(urdfdom_model ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
- set_target_properties(urdfdom_model PROPERTIES SOVERSION 0.3)
+ target_link_libraries(urdfdom_model ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
+ set_target_properties(urdfdom_model PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
  
 -add_library(urdfdom_sensor SHARED src/urdf_sensor.cpp)
 +add_library(urdfdom_sensor src/urdf_sensor.cpp)
- target_link_libraries(urdfdom_sensor urdfdom_model ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
- set_target_properties(urdfdom_sensor PROPERTIES SOVERSION 0.3)
+ target_link_libraries(urdfdom_sensor urdfdom_model ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
+ set_target_properties(urdfdom_sensor PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
  
 -add_library(urdfdom_model_state SHARED src/urdf_model_state.cpp src/twist.cpp)
 +add_library(urdfdom_model_state src/urdf_model_state.cpp src/twist.cpp)
- target_link_libraries(urdfdom_model_state ${tinyxml_libraries} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
- set_target_properties(urdfdom_model_state PROPERTIES SOVERSION 0.3)
+ target_link_libraries(urdfdom_model_state ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES} ${Boost_LIBRARIES})
+ set_target_properties(urdfdom_model_state PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
  
+ # --------------------------------
+ 
+-add_executable(check_urdf src/check_urdf.cpp)
+-target_link_libraries(check_urdf urdfdom_model urdfdom_world)
++if(NOT ANDROID)
++  add_executable(check_urdf src/check_urdf.cpp)
++  target_link_libraries(check_urdf urdfdom_model urdfdom_world)
+ 
+-add_executable(urdf_to_graphiz src/urdf_to_graphiz.cpp)
+-target_link_libraries(urdf_to_graphiz urdfdom_model)
++  add_executable(urdf_to_graphiz src/urdf_to_graphiz.cpp)
++  target_link_libraries(urdf_to_graphiz urdfdom_model)
+ 
+-# urdf_mem_test is a binary for testing, not a unit test
+-add_executable(urdf_mem_test test/memtest.cpp)
+-target_link_libraries(urdf_mem_test urdfdom_model)
++  # urdf_mem_test is a binary for testing, not a unit test
++  add_executable(urdf_mem_test test/memtest.cpp)
++  target_link_libraries(urdf_mem_test urdfdom_model)
+ 
+-# unit test to fix geometry problems
+-add_executable(urdf_unit_test test/urdf_unit_test.cpp)
+-target_link_libraries(urdf_unit_test urdfdom_model ${Boost_LIBRARIES})
+-add_test(urdf_unit_test urdf_unit_test)
++  # unit test to fix geometry problems
++  add_executable(urdf_unit_test test/urdf_unit_test.cpp)
++  target_link_libraries(urdf_unit_test urdfdom_model ${Boost_LIBRARIES})
++  add_test(urdf_unit_test urdf_unit_test)
++endif()
+ 
+ INSTALL(TARGETS urdfdom_model DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ INSTALL(TARGETS urdfdom_world DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-INSTALL(TARGETS check_urdf urdf_to_graphiz urdf_mem_test
+-  DESTINATION ${CMAKE_INSTALL_BINDIR})
++if(NOT ANDROID)
++  INSTALL(TARGETS check_urdf urdf_to_graphiz urdf_mem_test
++    DESTINATION ${CMAKE_INSTALL_BINDIR})
++endif()
+ INSTALL(TARGETS urdfdom_sensor DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ INSTALL(TARGETS urdfdom_model_state DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ INSTALL(DIRECTORY include/urdf_parser DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
... to the newest available releases with the same major.minor versions as the equivalent packages in Xenial/Kinetic.

- `console_bridge`: `0.2.8` -> `0.3.2` (https://github.com/ros/console_bridge/compare/964a9a70e0fc607476e439b8947a36b07322c304...0.3.2)
  - Same version as in xenial.
- `urdfdom-headers`: `1.0.0` -> `0.4.2` (https://github.com/ros/urdfdom_headers/compare/0.4.2...9aed7256e06d62935966de2a9bc9ddfac96e7a85)
  - xenial has `0.4.1` (https://github.com/ros/urdfdom_headers/compare/0.4.1...0.4.2).
  - Technically a downgrade, but the two versions are exactly the same. It should never have been called `1.0.0` because the version referenced before does not have all the unboostify patches from https://github.com/ros/urdfdom_headers/pull/23.
- `urdfdom`: `0.3.2` -> `0.4.2` (https://github.com/ros/urdfdom/compare/c4ac03caf55369c64c61605b78f1b6071bb4acce...0.4.2)
  - xenial has `0.4.1` (https://github.com/ros/urdfdom/compare/0.4.1...0.4.2).
  - Not sure why this could have worked before. As far as I know the two packages have to have (or at least should have) matching versions.
- `collada_dom`: `2.4.0` -> `2.4.4` (https://github.com/rdiankov/collada-dom/tree/v2.4.4)
  - Same version as in xenial.
  - Version 2.4.0 was not yet available on GitHub (or is not tagged).