### PR TITLE
Droped log4cxx

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -136,7 +136,6 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/pcl-pcl-1.8.1 ] || run_cmd get_library pcl $prefix/libs
 [ -d $prefix/libs/bfl-0.7.0 ] || run_cmd get_library bfl $prefix/libs
 [ -d $prefix/libs/orocos_kdl-1.3.0 ] || run_cmd get_library orocos_kdl $prefix/libs
-[ -d $prefix/libs/apache-log4cxx-0.10.0 ] || run_cmd get_library log4cxx $prefix/libs
 [ -d $prefix/libs/libccd-2.0 ] || run_cmd get_library libccd $prefix/libs
 [ -d $prefix/libs/fcl-0.3.2 ] || run_cmd get_library fcl $prefix/libs
 [ -d $prefix/libs/pcrecpp ] || run_cmd get_library pcrecpp $prefix/libs
@@ -184,9 +183,6 @@ if [[ $skip -ne 1 ]] ; then
 
     # Patch orocos_kdl - Build as static lib and change constant name
     apply_patch $my_loc/patches/orocos_kdl.patch
-
-    # Patch log4cxx - Add missing headers
-    apply_patch $my_loc/patches/log4cxx.patch
 
     # Patch fcl - Add ccd library cmake variables
     # TODO: The correct way to handle this would be to create .cmake files for ccd and do a findpackage(ccd)
@@ -355,7 +351,6 @@ echo
 [ -f $prefix/target/lib/libpcl_common.a ] || run_cmd build_library pcl $prefix/libs/pcl-pcl-1.8.1
 [ -f $prefix/target/lib/liborocos-bfl.a ] || run_cmd build_library bfl $prefix/libs/bfl-0.7.0
 [ -f $prefix/target/lib/liborocos-kdl.a ] || run_cmd build_library orocos_kdl $prefix/libs/orocos_kdl-1.3.0
-[ -f $prefix/target/lib/liblog4cxx.a ] || run_cmd build_library_with_toolchain log4cxx $prefix/libs/apache-log4cxx-0.10.0
 [ -f $prefix/target/lib/libccd.a ] || run_cmd build_library libccd $prefix/libs/libccd-2.0
 # [ -f $prefix/target/lib/libfcl.a ] || run_cmd build_library fcl $prefix/libs/fcl-0.3.2
 # [ -f $prefix/target/lib/libpcrecpp.a ] || run_cmd build_library pcrecpp $prefix/libs/pcrecpp

--- a/get_library.sh
+++ b/get_library.sh
@@ -59,9 +59,6 @@ elif [ $1 == 'libccd' ]; then
 elif [ $1 == 'libiconv' ]; then
     URL=http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz
     COMP='gz'
-elif [ $1 == 'log4cxx' ]; then
-    URL=http://mirrors.sonic.net/apache/logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz
-    COMP='gz'
 elif [ $1 == 'libxml2' ]; then
     URL=ftp://xmlsoft.org/libxml2/libxml2-2.9.1.tar.gz
     COMP='gz'


### PR DESCRIPTION
As was pointed out in #12, log4cxx was built with the host architecture. It is an optional backend for rosconsole: https://github.com/ros/rosconsole/blob/melodic-devel/CMakeLists.txt

The other backends available are:
- glog
- print (not external library needed)

Checking how prior ros indigo android version worked, I found that log4cxx had the same problem and print was used as backend.
I also tried solving log4cxx problems without success.

Here I'm deleting log4cxx, and print will continue as the backend used.
