### PR TITLE
Add libpng and libjpeg

### DIFF
--- a/build_library_with_toolchain.sh
+++ b/build_library_with_toolchain.sh
@@ -47,7 +47,7 @@ elif [ $1 == 'libxml2' ]; then
     configure_options="$configure_options --without-python"
 elif [ $1 == 'zlib' ]; then
     # Overwritten configure_options, as zlib doesn't support --disable-shared, --enable-static, --build=, --host=
-    configure_options='--prefix=$CMAKE_PREFIX_PATH --static --archs="'"-arch ${arch}"'"'
+    configure_options="--prefix=$CMAKE_PREFIX_PATH --static"
     # zlib needs CROSS_PREFIX exported
     export CROSS_PREFIX=${host}-
 fi

--- a/build_library_with_toolchain.sh
+++ b/build_library_with_toolchain.sh
@@ -45,6 +45,11 @@ elif [ $1 == 'curl' ]; then
     configure_options="$configure_options --without-ssl --disable-tftp --disable-sspi --disable-ipv6 --disable-ldaps --disable-ldap --disable-telnet --disable-pop3 --disable-ftp --disable-imap --disable-smtp --disable-pop3 --disable-rtsp --disable-ares --without-ca-bundle --disable-warnings --disable-manual --without-nss --without-random"
 elif [ $1 == 'libxml2' ]; then
     configure_options="$configure_options --without-python"
+elif [ $1 == 'zlib' ]; then
+    # Overwritten configure_options, as zlib doesn't support --disable-shared, --enable-static, --build=, --host=
+    configure_options='--prefix=$CMAKE_PREFIX_PATH --static --archs="'"-arch ${arch}"'"'
+    # zlib needs CROSS_PREFIX exported
+    export CROSS_PREFIX=${host}-
 fi
 
 # Configure and build

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -137,7 +137,7 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/pcrecpp ] || run_cmd get_library pcrecpp $prefix/libs
 [ -d $prefix/libs/zlib-1.2.11 ] || run_cmd get_library zlib $prefix/libs
 [ -d $prefix/libs/libpng-1.2.59 ] || run_cmd get_library libpng $prefix/libs
-[ -d $prefix/libs/jpeg-8c ] || run_cmd get_library libjpeg8 $prefix/libs
+[ -d $prefix/libs/jpeg-9c ] || run_cmd get_library libjpeg $prefix/libs
 # get rospkg dependency for pluginlib support at build time
 [ -d $my_loc/files/rospkg ] || run_cmd get_library rospkg $my_loc/files
 
@@ -346,7 +346,7 @@ echo
 [ -f $prefix/target/lib/libccd.a ] || run_cmd build_library libccd $prefix/libs/libccd-2.0
 [ -f $prefix/target/lib/libz.a ] || run_cmd build_library_with_toolchain zlib $prefix/libs/zlib-1.2.11
 [ -f $prefix/target/lib/libpng.a ] || run_cmd build_library_with_toolchain libpng $prefix/libs/libpng-1.2.59
-[ -f $prefix/target/lib/libjpeg.a ] || run_cmd build_library_with_toolchain libjpeg8 $prefix/libs/jpeg-8c
+[ -f $prefix/target/lib/libjpeg.a ] || run_cmd build_library_with_toolchain libjpeg $prefix/libs/jpeg-9c
 # [ -f $prefix/target/lib/libfcl.a ] || run_cmd build_library fcl $prefix/libs/fcl-0.3.2
 # [ -f $prefix/target/lib/libpcrecpp.a ] || run_cmd build_library pcrecpp $prefix/libs/pcrecpp
 

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -137,6 +137,7 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/pcrecpp ] || run_cmd get_library pcrecpp $prefix/libs
 [ -d $prefix/libs/zlib-1.2.11 ] || run_cmd get_library zlib $prefix/libs
 [ -d $prefix/libs/libpng-1.2.59 ] || run_cmd get_library libpng $prefix/libs
+[ -d $prefix/libs/jpeg-8c ] || run_cmd get_library libjpeg8 $prefix/libs
 # get rospkg dependency for pluginlib support at build time
 [ -d $my_loc/files/rospkg ] || run_cmd get_library rospkg $my_loc/files
 
@@ -345,6 +346,7 @@ echo
 [ -f $prefix/target/lib/libccd.a ] || run_cmd build_library libccd $prefix/libs/libccd-2.0
 [ -f $prefix/target/lib/libz.a ] || run_cmd build_library_with_toolchain zlib $prefix/libs/zlib-1.2.11
 [ -f $prefix/target/lib/libpng.a ] || run_cmd build_library_with_toolchain libpng $prefix/libs/libpng-1.2.59
+[ -f $prefix/target/lib/libjpeg.a ] || run_cmd build_library_with_toolchain libjpeg8 $prefix/libs/jpeg-8c
 # [ -f $prefix/target/lib/libfcl.a ] || run_cmd build_library fcl $prefix/libs/fcl-0.3.2
 # [ -f $prefix/target/lib/libpcrecpp.a ] || run_cmd build_library pcrecpp $prefix/libs/pcrecpp
 

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -135,6 +135,8 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/libccd-2.0 ] || run_cmd get_library libccd $prefix/libs
 [ -d $prefix/libs/fcl-0.3.2 ] || run_cmd get_library fcl $prefix/libs
 [ -d $prefix/libs/pcrecpp ] || run_cmd get_library pcrecpp $prefix/libs
+[ -d $prefix/libs/zlib-1.2.11 ] || run_cmd get_library zlib $prefix/libs
+[ -d $prefix/libs/libpng-1.2.59 ] || run_cmd get_library libpng $prefix/libs
 # get rospkg dependency for pluginlib support at build time
 [ -d $my_loc/files/rospkg ] || run_cmd get_library rospkg $my_loc/files
 
@@ -341,6 +343,8 @@ echo
 [ -f $prefix/target/lib/libflann_cpp_s.a ] || run_cmd build_library flann $prefix/libs/flann
 [ -f $prefix/target/lib/libpcl_common.a ] || run_cmd build_library pcl $prefix/libs/pcl-pcl-1.8.1
 [ -f $prefix/target/lib/libccd.a ] || run_cmd build_library libccd $prefix/libs/libccd-2.0
+[ -f $prefix/target/lib/libz.a ] || run_cmd build_library_with_toolchain zlib $prefix/libs/zlib-1.2.11
+[ -f $prefix/target/lib/libpng.a ] || run_cmd build_library_with_toolchain libpng $prefix/libs/libpng-1.2.59
 # [ -f $prefix/target/lib/libfcl.a ] || run_cmd build_library fcl $prefix/libs/fcl-0.3.2
 # [ -f $prefix/target/lib/libpcrecpp.a ] || run_cmd build_library pcrecpp $prefix/libs/pcrecpp
 

--- a/get_library.sh
+++ b/get_library.sh
@@ -54,6 +54,9 @@ elif [ $1 == 'libccd' ]; then
 elif [ $1 == 'libiconv' ]; then
     URL=http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz
     COMP='gz'
+elif [ $1 == 'libpng' ]; then
+    URL=https://sourceforge.net/projects/libpng/files/libpng12/1.2.59/libpng-1.2.59.tar.gz/download
+    COMP='gz'
 elif [ $1 == 'libxml2' ]; then
     URL=ftp://xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz
     COMP='gz'
@@ -96,6 +99,9 @@ elif [ $1 == 'rospkg' ]; then
     URL=https://github.com/ros-infrastructure/rospkg.git
     COMP='git'
     HASH='93b1b72f256badf22ccc926b22646f2e83b720fd'
+elif [ $1 == 'zlib' ]; then
+    URL=http://prdownloads.sourceforge.net/libpng/zlib-1.2.11.tar.gz
+    COMP='gz'
 fi
 
 if [ $COMP == 'gz' ]; then

--- a/get_library.sh
+++ b/get_library.sh
@@ -54,6 +54,9 @@ elif [ $1 == 'libccd' ]; then
 elif [ $1 == 'libiconv' ]; then
     URL=http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz
     COMP='gz'
+elif [ $1 == 'libjpeg8' ]; then
+    URL=http://www.ijg.org/files/jpegsrc.v8c.tar.gz
+    COMP='gz'
 elif [ $1 == 'libpng' ]; then
     URL=https://sourceforge.net/projects/libpng/files/libpng12/1.2.59/libpng-1.2.59.tar.gz/download
     COMP='gz'

--- a/get_library.sh
+++ b/get_library.sh
@@ -54,8 +54,8 @@ elif [ $1 == 'libccd' ]; then
 elif [ $1 == 'libiconv' ]; then
     URL=http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz
     COMP='gz'
-elif [ $1 == 'libjpeg8' ]; then
-    URL=http://www.ijg.org/files/jpegsrc.v8c.tar.gz
+elif [ $1 == 'libjpeg' ]; then
+    URL=http://www.ijg.org/files/jpegsrc.v9c.tar.gz
     COMP='gz'
 elif [ $1 == 'libpng' ]; then
     URL=https://sourceforge.net/projects/libpng/files/libpng12/1.2.59/libpng-1.2.59.tar.gz/download


### PR DESCRIPTION
I have added this libraries because linking problems might appear later:
- libpng12 (1.2.59)
- libjpeg9 (v9c)
- zlib (1.2.11)

Another option is to add libjpeg-turbo, which is a faster version of libjpeg using SIMD (opencv doesn't use it by default).

I have later found that a version of libjpeg and libpng are already located in
target/share/OpenCV-3.3.1-dev/3rdparty/lib/
but  zlib references are still undefined there.