### PR TITLE
Set CMAKE_BUILD_TYPE for 3rd-party cmake libs

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -48,6 +48,7 @@ cmake_build() {
     cd $1
     mkdir -p build && cd build
     cmake .. -DCMAKE_TOOLCHAIN_FILE=$RBA_TOOLCHAIN \
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
         -DANDROID_ABI=arm64-v8a -DANDROID_NATIVE_API_LEVEL=$platform \
         -DPYTHON_EXECUTABLE=$python -DCMAKE_INSTALL_PREFIX=$target -DBUILD_SHARED_LIBS=0 -DPCL_SHARED_LIBS=FALSE \
         -DCMAKE_FIND_ROOT_PATH=$target \

--- a/utils.sh
+++ b/utils.sh
@@ -61,7 +61,7 @@ apply_patch() {
     echo "Checking patch: $1"
     if patch -p0 -N --dry-run --silent -d $prefix < $1;
     then
-        patch -p0 -N -d $prefix < $1
+        patch -p0 -N -d $prefix < $1 || return $?
     fi
     echo ''
 }


### PR DESCRIPTION
Or use `-DCMAKE_BUILD_TYPE=Release` independent of what is configured in [config.sh](https://github.com/Intermodalics/ros_android/blob/a1bdb6e2b656862d7c4ddf30f57c93261e5ff36d/config.sh#L15)?

The second patch partially addresses #29.