### PR TITLE
Comment tf2_py in ndk.rosinstall instead of removing it afterwards

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -206,9 +206,6 @@ if [[ $skip -ne 1 ]] ; then
     # Patch xmlrpcpp - problems with Boost changes.
     apply_patch $my_loc/patches/xmlrpcpp.patch
 
-    # Remove
-    rm -fr $prefix/catkin_ws/src/geometry2/tf2_py
-
     # Patch roslib - weird issue with rospack.
     # TODO: Need to look further (only on catkin_make_isolated)
     # apply_patch /opt/roscpp_android/patches/roslib.patch

--- a/ndk.rosinstall
+++ b/ndk.rosinstall
@@ -214,10 +214,10 @@
     local-name: geometry2/tf2_msgs
     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_msgs/0.5.18-0.tar.gz
     version: geometry2-release-release-kinetic-tf2_msgs-0.5.18-0
-- tar:
-    local-name: geometry2/tf2_py
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_py/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2_py-0.5.18-0
+# - tar:
+#     local-name: geometry2/tf2_py
+#     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_py/0.5.18-0.tar.gz
+#     version: geometry2-release-release-kinetic-tf2_py-0.5.18-0
 - tar:
     local-name: geometry2/tf2_ros
     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_ros/0.5.18-0.tar.gz


### PR DESCRIPTION
Not much to say about this one. The package got downloaded and removed each time `do_everything.sh` is called.