### PR TITLE
Remove or comment out unneeded patches

### DIFF
--- a/build_library.sh
+++ b/build_library.sh
@@ -18,15 +18,3 @@ echo -e '\e[34mBuilding '$1.'\e[39m'
 echo
 
 cmake_build $2
-
-if [ $1 == 'eigen' ]; then
-	cp -r $CMAKE_PREFIX_PATH/include/eigen3/* $CMAKE_PREFIX_PATH/include
-fi
-
-# TODO(ivanpauno): Check this later.
-# if [ $1 == 'opencv' ]; then
-#     echo "Copy opencv 3rdparty libraries to the lib folder."
-#     echo "These are needed to build the compressed image transport plugin."
-#     (cp $2/build/3rdparty/lib/* $2/../../target/lib/)
-# fi
-

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -365,7 +365,7 @@ echo
 
 # Library path is incorrect for urdf.
 # TODO: Need to investigate the source of the issue
-sed -i 's/set(libraries "urdf;/set(libraries "/g' $CMAKE_PREFIX_PATH/share/urdf/cmake/urdfConfig.cmake
+#sed -i 's/set(libraries "urdf;/set(libraries "/g' $CMAKE_PREFIX_PATH/share/urdf/cmake/urdfConfig.cmake
 
 run_cmd create_android_mk $prefix/catkin_ws/src $prefix/roscpp_android_ndk
 


### PR DESCRIPTION
I built and used the target-space successfully even without the Eigen headers patch. Of course all packages need to find Eigen (e.g. using the installed cmake configuration `Eigen3Config.cmake`) and add the `EIGEN3_INCLUDE_DIRS` to the list of include directories. If they do not, copying the headers to the global include directory would be an improper workaround.

The already commented section about `opencv` 3rd-party libraries is not needed either, at least not in combination with #51.

The `urdf` library patch should also not be required. The package does install a `liburdf.a` archive, but at the moment it is commented in [ndk.rosinstall](https://github.com/Intermodalics/ros_android/blob/e2dc839b3f6e895fd851f40ba59c8a139f97baec/ndk.rosinstall#L677-L680) anyway. 