### PR TITLE
Upgrade lz4 to r131 (xenial version)

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -108,7 +108,7 @@ export RBA_TOOLCHAIN=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 [ -d $prefix/libs/tinyxml ] || run_cmd get_library tinyxml $prefix/libs
 [ -d $prefix/libs/tinyxml2 ] || run_cmd get_library tinyxml2 $prefix/libs
 [ -d $prefix/libs/console_bridge ] || run_cmd get_library console_bridge $prefix/libs
-[ -d $prefix/libs/lz4-r124 ] || run_cmd get_library lz4 $prefix/libs
+[ -d $prefix/libs/lz4-r131 ] || run_cmd get_library lz4 $prefix/libs
 [ -d $prefix/libs/curl-7.47.0 ] || run_cmd get_library curl $prefix/libs
 [ -d $prefix/libs/urdfdom/ ] || run_cmd get_library urdfdom $prefix/libs
 [ -d $prefix/libs/urdfdom_headers ] || run_cmd get_library urdfdom_headers $prefix/libs
@@ -311,7 +311,7 @@ echo
 [ -f $prefix/target/lib/libtinyxml.a ] || run_cmd build_library tinyxml $prefix/libs/tinyxml
 [ -f $prefix/target/lib/libtinyxml2.a ] || run_cmd build_library tinyxml2 $prefix/libs/tinyxml2
 [ -f $prefix/target/lib/libconsole_bridge.a ] || run_cmd build_library console_bridge $prefix/libs/console_bridge
-[ -f $prefix/target/lib/liblz4.a ] || run_cmd build_library lz4 $prefix/libs/lz4-r124/cmake_unofficial
+[ -f $prefix/target/lib/liblz4.a ] || run_cmd build_library lz4 $prefix/libs/lz4-r131/cmake_unofficial
 [ -f $prefix/target/lib/libcurl.a ] || run_cmd build_library_with_toolchain curl $prefix/libs/curl-7.47.0
 [ -f $prefix/target/include/urdf_model/model.h ] || run_cmd build_library urdfdom_headers $prefix/libs/urdfdom_headers
 [ -f $prefix/target/lib/liburdfdom_model.a ] || run_cmd build_library urdfdom $prefix/libs/urdfdom

--- a/get_library.sh
+++ b/get_library.sh
@@ -52,7 +52,7 @@ elif [ $1 == 'libxml2' ]; then
     URL=ftp://xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz
     COMP='gz'
 elif [ $1 == 'lz4' ]; then
-    URL=https://github.com/Cyan4973/lz4/archive/r124.tar.gz
+    URL=https://github.com/Cyan4973/lz4/archive/r131.tar.gz
     COMP='gz'
 elif [ $1 == 'pcl' ]; then
     URL=https://github.com/PointCloudLibrary/pcl/archive/pcl-1.8.1.tar.gz


### PR DESCRIPTION
r124 does not support aarch64, probably due to the CPU feature detection at
[lz4.c](https://github.com/lz4/lz4/compare/r124...r131#diff-a4dc0fa3ccaea8a4219c81928cba271aL49).

Using `rosbag` with lz4 compression causes a segfault on Android. To be confirmed whether upgrading lz4 solves that issue.