### PR TITLE
docker: build on top of ros:kinetic-ros-core-xenial without preinstalled ros-base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:kinetic-ros-base-xenial
+FROM ros:kinetic-ros-core-xenial
 MAINTAINER Julian Cerruti <jcerruti@ekumenlabs.com>
 MAINTAINER Gary Servin <gary@ekumenlabs.com>
 MAINTAINER Juan Ignacio Ubeira <jubeira@ekumenlabs.com>


### PR DESCRIPTION
A minor optimization. We do not use the ROS installation on the host or in the container at all anymore since https://github.com/Intermodalics/ros_android/commit/4ec492dc76d6410b8fb61da893e95df4c728bc33.

Meta-package [ros_base](https://github.com/ros/metapackages/blob/melodic-devel/ros_base/package.xml) has some additional packages which are not needed to build the ROS Android NDK:
> A metapackage which extends ros_core and includes other basic non-robot tools like actionlib, dynamic reconfigure, nodelets, and pluginlib

Eventually we could start from scratch [ubuntu:xenial](https://hub.docker.com/_/ubuntu/) as most of the other stuff in [ros-core/Dockerfile](https://github.com/osrf/docker_images/blob/master/ros/kinetic/ubuntu/xenial/ros-core/Dockerfile) is also not needed anymore.