### PR TITLE
opencv: patch 3rdparty/libtiff/CMakeLists.txt to fix unknown CMake command error

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -87,7 +87,6 @@ mkdir -p $prefix/libs
 
 # Start with catkin since we use it to build almost everything else
 [ -d $prefix/target ] || mkdir -p $prefix/target
-export CMAKE_PREFIX_PATH=$prefix/target
 
 # Get the android ndk build helper script
 # If file doesn't exist, then download and patch it

--- a/get_ros_stuff.sh
+++ b/get_ros_stuff.sh
@@ -17,9 +17,6 @@ cmd_exists git || die 'git was not found'
 
 prefix=$(cd $1 && pwd)
 
-[ "$CMAKE_PREFIX_PATH" = "" ] && die 'could not find target basedir. Have you run build_catkin.sh and sourced setup.bash?'
-
-#cd $CMAKE_PREFIX_PATH
 cd $prefix
 mkdir -p catkin_ws/src && cd catkin_ws
 

--- a/patches/opencv.patch
+++ b/patches/opencv.patch
@@ -101,4 +101,13 @@
 +            DESTINATION ${OPENCV_OTHER_INSTALL_PATH} COMPONENT libs)
    endif()
  endif()
+--- catkin_ws/src/opencv3/3rdparty/libtiff/CMakeLists.txt
++++ catkin_ws/src/opencv3/3rdparty/libtiff/CMakeLists.txt
+@@ -7,6 +7,7 @@
+ include(CheckCSourceCompiles)
+ include(CheckFunctionExists)
+ include(CheckIncludeFile)
++include(CheckTypeSize)
  
+ 
+ # Find libm, if available 


### PR DESCRIPTION
Not sure why this was only triggered after a fresh rebuild:
```
CMake Error at /opt/ros_android/catkin_ws /src/opencv3/3rdparty/libtiff/CMakeLists.txt:67 (check_type_size):
  Unknown CMake command "check_type_size".
```