### PR TITLE
build_library_with_toolchain.sh: fix calls to autogen for vorbis and theora

### DIFF
--- a/build_library_with_toolchain.sh
+++ b/build_library_with_toolchain.sh
@@ -67,8 +67,8 @@ elif [ $1 == 'vorbis' ]; then
     # TODO(ivanpauno): Check why --with-ogg=prefix isn't working.
     export OGG_CFLAGS=-I${CMAKE_PREFIX_PATH}/include
     export OGG_LIBS=-L${CMAKE_PREFIX_PATH}/lib
-    # Regenerate ./configure
-    ./autogen.sh
+    # Regenerate and call ./configure
+    ./autogen.sh ${configure_options}
 elif [ $1 == 'theora' ]; then
     # Update old config.sub and config.guess
     cp /usr/share/automake*/config* .
@@ -77,8 +77,8 @@ elif [ $1 == 'theora' ]; then
     # Specify OGG and vorbis location
     export OGG_CFLAGS=-I${CMAKE_PREFIX_PATH}/include
     export OGG_LIBS=-L${CMAKE_PREFIX_PATH}/lib
-    # Regenerate ./configure
-    ./autogen.sh
+    # Regenerate and call ./configure
+    ./autogen.sh ${configure_options}
 fi
 
 # Configure and build


### PR DESCRIPTION
`autogen.sh` calls `./configure` internally and already needs the full list of command line arguments.

I got errors during a fresh build after I set `CXXFLAGS` because `configure` tried to build something using the host compiler that does not support the added flags.