### PR TITLE
catkin: add a patch that allows to pass arbitrary linker flags via catkin_LIBRARIES

### DIFF
--- a/patches/catkin.patch
+++ b/patches/catkin.patch
@@ -86,3 +86,15 @@
    #set(_argn ${ARGN})
    #debug_message(10 "catkin_replace_imported_library_targets(${VAR} ${_argn}) ${result}")
    set(${VAR} "${result}" PARENT_SCOPE)
+--- catkin_ws/src/catkin/cmake/templates/pkgConfig.cmake.in
++++ catkin_ws/src/catkin/cmake/templates/pkgConfig.cmake.in
+@@ -121,6 +121,9 @@ foreach(library ${libraries})
+   # keep build configuration keywords, target names and absolute libraries as-is
+   if("${library}" MATCHES "^(debug|optimized|general)$")
+     list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
++  elseif("${library}" MATCHES "^-.*$")
++    # for flags, e.g. -fopenmp
++    list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
+   elseif(TARGET ${library})
+     list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
+   elseif(IS_ABSOLUTE ${library})


### PR DESCRIPTION
Required for packages that depend on OpenMP, but also for other use cases. For example, I remember a discussion about Gazebo exporting `-pthread` or `-lpthread` in its CMake configuration (https://github.com/ros/catkin/issues/856, https://github.com/ros/catkin/pull/975).

OpenMP is supported on Android with clang, but requires to pass `-fopenmp` in the linker command line of all downstream package. Other methods, like linking to `gomp` do not work because this library does not exist on Android or in the NDK.

With this patch, it is possible to export linker flags like
```cmake
catkin_package(
  LIBRARIES -fopenmp
)
```

or (on Linux, not for Android)
```cmake
catkin_package(
  DEPENDS GAZEBO
)

# GAZEBO_LIBRARIES = BulletSoftBody;BulletDynamics;BulletCollision;LinearMath;/usr/lib/x86_64-linux-gnu/libSimTKsimbody.so;/usr/lib/x86_64-linux-gnu/libSimTKmath.so;/usr/lib/x86_64-linux-gnu/libSimTKcommon.so;/usr/lib/libblas.so;/usr/lib/liblapack.so;/usr/lib/libblas.so;pthread;rt;dl;m;/usr/lib/x86_64-linux-gnu/libgazebo.so;/usr/lib/x86_64-linux-gnu/libgazebo_client.so;/usr/lib/x86_64-linux-gnu/libgazebo_gui.so;/usr/lib/x86_64-linux-gnu/libgazebo_sensors.so;/usr/lib/x86_64-linux-gnu/libgazebo_rendering.so;/usr/lib/x86_64-linux-gnu/libgazebo_physics.so;/usr/lib/x86_64-linux-gnu/libgazebo_ode.so;/usr/lib/x86_64-linux-gnu/libgazebo_transport.so;/usr/lib/x86_64-linux-gnu/libgazebo_msgs.so;/usr/lib/x86_64-linux-gnu/libgazebo_util.so;/usr/lib/x86_64-linux-gnu/libgazebo_common.so;/usr/lib/x86_64-linux-gnu/libgazebo_gimpact.so;/usr/lib/x86_64-linux-gnu/libgazebo_opcode.so;/usr/lib/x86_64-linux-gnu/libgazebo_opende_ou.so;/usr/lib/x86_64-linux-gnu/libgazebo_math.so;/usr/lib/x86_64-linux-gnu/libgazebo_ccd.so;/usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/libboost_signals.so;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libboost_filesystem.so;/usr/lib/x86_64-linux-gnu/libboost_program_options.so;/usr/lib/x86_64-linux-gnu/libboost_regex.so;/usr/lib/x86_64-linux-gnu/libboost_iostreams.so;/usr/lib/x86_64-linux-gnu/libboost_date_time.so;/usr/lib/x86_64-linux-gnu/libboost_chrono.so;/usr/lib/x86_64-linux-gnu/libboost_atomic.so;/usr/lib/x86_64-linux-gnu/libprotobuf.so;-lpthread;/usr/lib/x86_64-linux-gnu/libsdformat.so;ignition-math3;optimized;/usr/lib/x86_64-linux-gnu/libOgreMain.so;debug;/usr/lib/x86_64-linux-gnu/libOgreMain.so;/usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/libboost_date_time.so;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libboost_atomic.so;/usr/lib/x86_64-linux-gnu/libboost_chrono.so;optimized;/usr/lib/x86_64-linux-gnu/libOgreTerrain.so;debug;/usr/lib/x86_64-linux-gnu/libOgreTerrain.so;optimized;/usr/lib/x86_64-linux-gnu/libOgrePaging.so;debug;/usr/lib/x86_64-linux-gnu/libOgrePaging.so;ignition-math3;/usr/lib/x86_64-linux-gnu/libignition-transport3.so;/usr/lib/x86_64-linux-gnu/libprotobuf.so;-lpthread;zmq;uuid;ignition-msgs0;ignition-math3;ignition-msgs0;ignition-math3
```

A better approach would be to handle linker flags (and compiler options) separately and not "misuse" the exported libraries for that. But it does work like that and many commonly used CMake configuration scripts export linker flags in `_LIBRARIES`. [target_link_libraries()](https://cmake.org/cmake/help/v3.0/command/target_link_libraries.html) explicitly allows to pass linker flags and handles them separately.