### PR TITLE
Pluginlib helper searching in multiple workspaces

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -44,7 +44,7 @@ do
             help=1
         fi
         shift
-    elif [[ -z prefix ]]
+    elif [[ ! -z prefix ]]; then
         if [ ! -d $1 ]; then
             mkdir -p $1
         fi
@@ -54,7 +54,7 @@ do
 done
 
 if [[ -z prefix ]]; then
-    help = 1
+    help=1
 fi
 
 if [[ $help -eq 1 ]] ; then

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -58,8 +58,9 @@ if [[ -z prefix ]]; then
 fi
 
 if [[ $help -eq 1 ]] ; then
-    echo "Usage: $0 prefix_path [-h | --help] [--skip] [--debug-symbols]"
+    echo "Usage: $0 prefix_path [-h | --help] [--skip] [--debug-symbols] [--extends-workspace path]"
     echo "  example: $0 /home/user/my_workspace"
+    echo " --extends-workspace path: Pluginlib will also search in this path for plugins."
     exit 1
 fi
 

--- a/files/pluginlib_helper/plugin_collect.py
+++ b/files/pluginlib_helper/plugin_collect.py
@@ -38,7 +38,7 @@ def collect_plugins(root_scan_dir):
   root_scan_dir indicates the starting point for the scan
   returns the collected plugin classes
   """
-  rp = RosPack([root_scan_dir])
+  rp = RosPack(root_scan_dir)
 
   packages = rp.list()
   debug_print("Found packages:\n")

--- a/files/pluginlib_helper/pluginlib_helper.py
+++ b/files/pluginlib_helper/pluginlib_helper.py
@@ -12,7 +12,7 @@ if cmd_folder not in sys.path:
 
 def main():
   parser = argparse.ArgumentParser()
-  parser.add_argument("-scanroot", nargs="?", default="", help="Root folder to start scanning for plugins.")
+  parser.add_argument("-scanroot", nargs="*", default="", help="Root folder to start scanning for plugins.")
   parser.add_argument("-cppout", nargs="?", default="", help="Name of the cpp output file that will contain the static plugin loader code.")
   parser.add_argument("-buildfile", nargs="?", default="", help="Name of the build file.")
   


### PR DESCRIPTION
If a plugin was registered in other workspace, pluginlib_helper didn't found it and didn't added the appropriate entry to getStaticClassesAvailable().
I added to do_everything an optional argument "--extends-workspace PATH", in which pluginlib_helper will also look. Pluginlib should be recompiled after adding a plugin.