### PR TITLE
get_system_dependencies: fix permission errors when copying rospkg to files/ the second time

### DIFF
--- a/get_system_dependencies.sh
+++ b/get_system_dependencies.sh
@@ -40,4 +40,4 @@ pushd $lib_prefix/boost
 popd
 
 # Rospkg
-cp -r $lib_prefix/rospkg $files_prefix
+cp -rn $lib_prefix/rospkg $files_prefix


### PR DESCRIPTION
Some files in `.git` have are read-only even for the user (`-r--r--r--`). When copying the tree to `files/rospkg` the second time, `cp` errors out because it cannot overwrite the existing files:
```sh
cp: cannot create regular file 'files/rospkg/.git/objects/pack/pack-63cfdf1329681d113714babd9484539aa374a166.pack': Permission denied
cp: cannot create regular file 'files/rospkg/.git/objects/pack/pack-63cfdf1329681d113714babd9484539aa374a166.idx': Permission denied

$ ls -als files/rospkg/.git/objects/pack/
total 528
  4 drwxrwxr-x 2 johannes intermodalics   4096 Jan 10 18:17 .
  4 drwxrwxr-x 4 johannes intermodalics   4096 Jan 10 18:17 ..
 68 -r--r--r-- 1 johannes intermodalics  68524 Jan 10 18:17 pack-63cfdf1329681d113714babd9484539aa374a166.idx
452 -r--r--r-- 1 johannes intermodalics 461844 Jan 10 18:17 pack-63cfdf1329681d113714babd9484539aa374a166.pack
```

This issue does not affect docker builds where all processes run with root permissions.