### PR TITLE
docker/run.sh: apply extra arguments to docker run instead of bash

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,5 @@
+build.sh
+Dockerfile
+.dockerignore
+README.md
+run.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,4 +43,4 @@ ENTRYPOINT []
 
 VOLUME /opt/ros_android
 WORKDIR /opt/ros_android
-CMD ['bash']
+CMD ["bash"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,5 +3,5 @@
 IMAGE=android_ndk
 
 pushd "$( dirname "${BASH_SOURCE[0]}" )"
-docker build -t ${IMAGE} .
+docker build -t ${IMAGE} "$@" .
 popd

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,9 +4,34 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 REPO_ROOT=$SCRIPTPATH/../
 IMAGE=android_ndk
 
+DOCKEROPTS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help)
+      # print usage
+      echo "Usage: $0 [DOCKER OPTIONS] [-- [COMMAND]]"
+      echo
+      echo "Docker options:"
+      docker run --help | tail -n +7
+      exit 0
+      ;;
+    --)
+      # end-of-options: all arguments after the -- will be interpreted as a command to run inside the container.
+      shift
+      break
+      ;;
+    *)
+      # collect docker options
+      DOCKEROPTS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -x
 docker run \
   -v ${REPO_ROOT}:/opt/ros_android \
   --privileged \
   -it \
-  "$@" \
-  ${IMAGE} bash
+  "${DOCKEROPTS[@]}" \
+  ${IMAGE} "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,14 +4,9 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 REPO_ROOT=$SCRIPTPATH/../
 IMAGE=android_ndk
 
-if [ "$#" == 0 ]; then
-  EXTRA_ARGS="bash"
-else
-  EXTRA_ARGS="bash -c \"$@\""
-fi
-
 docker run \
   -v ${REPO_ROOT}:/opt/ros_android \
   --privileged \
   -it \
-  ${IMAGE} "${EXTRA_ARGS}"
+  "$@" \
+  ${IMAGE} bash


### PR DESCRIPTION
This is needed to mount extra directories from the host, e.g. for the `do_everything.sh --extends-workspace` feature. But it might break existing use cases that expect the arguments to be a command to execute within the container.

If still needed, we could use `--` to split docker and bash arguments. Or handle well-known arguments or pairs like `-v <spec>` separately and only interpret the remaining arguments as a command.