### PR TITLE
 pluginlib_helper: also include implicit (indirect) dependencies

### DIFF
--- a/do_everything.sh
+++ b/do_everything.sh
@@ -137,6 +137,9 @@ if [ $? -ne 0 ]; then
     echo -e "\n"$line >> $prefix/catkin_ws/src/pluginlib/CMakeLists.txt
     echo 'install(TARGETS pluginlib RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})' >> $prefix/catkin_ws/src/pluginlib/CMakeLists.txt
 fi
+# Ignore packages that are just needed to build pluginlib support, but are just python packages with C bindings that won't build.
+touch $prefix/catkin_ws/src/geometry2/tf2_py/CATKIN_IGNORE
+touch $prefix/catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/CATKIN_IGNORE
 # turn error detection back on
 set -e
 

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -137,9 +137,6 @@ if [ $? -ne 0 ]; then
     echo -e "\n"$line >> $prefix/catkin_ws/src/pluginlib/CMakeLists.txt
     echo 'install(TARGETS pluginlib RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})' >> $prefix/catkin_ws/src/pluginlib/CMakeLists.txt
 fi
-# Ignore packages that are just needed to build pluginlib support, but are just python packages with C bindings that won't build.
-touch $prefix/catkin_ws/src/geometry2/tf2_py/CATKIN_IGNORE
-touch $prefix/catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/CATKIN_IGNORE
 # turn error detection back on
 set -e
 

--- a/files/pluginlib_helper/plugin_collect.py
+++ b/files/pluginlib_helper/plugin_collect.py
@@ -45,13 +45,8 @@ def collect_plugins(root_scan_dir):
   #print packages
   debug_print()
 
-  # Find all packages that depend on pluginlib and nodelet explicitely
-  pluginlib_users = rp.get_depends_on('pluginlib', implicit=False)
-  nodelet_users = rp.get_depends_on('nodelet', implicit=False)
-  image_transport_users = rp.get_depends_on('image_transport', implicit=False)
-  # Concatenate both lists removing the duplicates
-  pluginlib_users += list(set(nodelet_users) - set(pluginlib_users))
-  pluginlib_users += list(set(image_transport_users) - set(pluginlib_users))
+  # Find all packages that depend on pluginlib and nodelet explicitly or implicitly
+  pluginlib_users = set(rp.get_depends_on('pluginlib', implicit=True))
 
   debug_print("Packages that depend on pluginlib:\n")
   debug_print(pluginlib_users)

--- a/patches/python_orocos_kdl.patch
+++ b/patches/python_orocos_kdl.patch
@@ -1,20 +1,17 @@
 --- catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/CMakeLists.txt
 +++ catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/CMakeLists.txt
-@@ -1,7 +1,7 @@
- cmake_minimum_required(VERSION 2.4.6)
+@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 2.4.6)
  
  project(python_orocos_kdl)
--
-+if(NOT ANDROID)
+ 
++# Skip package if building for Android
++if(ANDROID)
++  find_package(catkin REQUIRED)
++  catkin_package()
++  return()
++endif()
++
  find_package(orocos_kdl)
  include_directories(${orocos_kdl_INCLUDE_DIRS})
  link_directories(${orocos_kdl_LIBRARY_DIRS})
-@@ -20,5 +20,5 @@ set(SIP_INCLUDES ${SIP_FILES})
- set(SIP_EXTRA_OPTIONS "-o")
- set(PYTHON_SITE_PACKAGES_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_PACKAGES})
- add_sip_python_module(PyKDL PyKDL/PyKDL.sip ${orocos_kdl_LIBRARIES})
--
--install(FILES package.xml DESTINATION share/python_orocos_kdl)
-\ No newline at end of file
-+endif()
-+install(FILES package.xml DESTINATION share/python_orocos_kdl)
+

--- a/patches/python_orocos_kdl.patch
+++ b/patches/python_orocos_kdl.patch
@@ -1,0 +1,20 @@
+--- catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/CMakeLists.txt
++++ catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 2.4.6)
+ 
+ project(python_orocos_kdl)
+-
++if(NOT ANDROID)
+ find_package(orocos_kdl)
+ include_directories(${orocos_kdl_INCLUDE_DIRS})
+ link_directories(${orocos_kdl_LIBRARY_DIRS})
+@@ -20,5 +20,5 @@ set(SIP_INCLUDES ${SIP_FILES})
+ set(SIP_EXTRA_OPTIONS "-o")
+ set(PYTHON_SITE_PACKAGES_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_PACKAGES})
+ add_sip_python_module(PyKDL PyKDL/PyKDL.sip ${orocos_kdl_LIBRARIES})
+-
+-install(FILES package.xml DESTINATION share/python_orocos_kdl)
+\ No newline at end of file
++endif()
++install(FILES package.xml DESTINATION share/python_orocos_kdl)

--- a/patches/python_orocos_kdl.patch
+++ b/patches/python_orocos_kdl.patch
@@ -15,3 +15,13 @@
  include_directories(${orocos_kdl_INCLUDE_DIRS})
  link_directories(${orocos_kdl_LIBRARY_DIRS})
 
+--- catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/package.xml
++++ catkin_ws/src/orocos_kinematics_dynamics/python_orocos_kdl/package.xml
+@@ -10,6 +10,7 @@
+   <license>LGPL</license>
+ 
+   <buildtool_depend>cmake</buildtool_depend>
++  <buildtool_depend>catkin</buildtool_depend>
+ 
+   <build_depend>orocos_kdl</build_depend>
+   <build_depend>python-sip</build_depend>

--- a/patches/tf2_py.patch
+++ b/patches/tf2_py.patch
@@ -1,18 +1,16 @@
 --- catkin_ws/src/geometry2/tf2_py/CMakeLists.txt
 +++ catkin_ws/src/geometry2/tf2_py/CMakeLists.txt
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,13 @@
  cmake_minimum_required(VERSION 2.8.3)
  project(tf2_py)
  
-+if(NOT ANDROID)
++# Skip package if building for Android
++if(ANDROID)
++  find_package(catkin REQUIRED)
++  catkin_package()
++  return()
++endif()
++
  ## Find catkin macros and libraries
  ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
  ## is used, also find other catkin packages
-@@ -155,3 +156,7 @@ install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.s
- 
- ## Add folders to be run by python nosetests
- # catkin_add_nosetests(test)
-+
-+else()
-+install(FILES package.xml DESTINATION share/tf2_py) # Dummy install
-+endif()

--- a/patches/tf2_py.patch
+++ b/patches/tf2_py.patch
@@ -1,0 +1,18 @@
+--- catkin_ws/src/geometry2/tf2_py/CMakeLists.txt
++++ catkin_ws/src/geometry2/tf2_py/CMakeLists.txt
+@@ -1,6 +1,7 @@
+ cmake_minimum_required(VERSION 2.8.3)
+ project(tf2_py)
+ 
++if(NOT ANDROID)
+ ## Find catkin macros and libraries
+ ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+ ## is used, also find other catkin packages
+@@ -155,3 +156,7 @@ install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.s
+ 
+ ## Add folders to be run by python nosetests
+ # catkin_add_nosetests(test)
++
++else()
++install(FILES package.xml DESTINATION share/tf2_py) # Dummy install
++endif()

--- a/ros.rosinstall
+++ b/ros.rosinstall
@@ -22,11 +22,10 @@
     local-name: bond_core/bondcpp
     uri: https://github.com/ros-gbp/bond_core-release/archive/release/kinetic/bondcpp/1.8.3-0.tar.gz
     version: bond_core-release-release-kinetic-bondcpp-1.8.3-0
-# Python based package, not needed
-# - tar:
-#     local-name: bond_core/bondpy
-#     uri: https://github.com/ros-gbp/bond_core-release/archive/release/kinetic/bondpy/1.8.3-0.tar.gz
-#     version: bond_core-release-release-kinetic-bondpy-1.8.3-0
+- tar:
+    local-name: bond_core/bondpy
+    uri: https://github.com/ros-gbp/bond_core-release/archive/release/kinetic/bondpy/1.8.3-0.tar.gz
+    version: bond_core-release-release-kinetic-bondpy-1.8.3-0
 - tar:
     local-name: bond_core/smclib
     uri: https://github.com/ros-gbp/bond_core-release/archive/release/kinetic/smclib/1.8.3-0.tar.gz
@@ -216,11 +215,10 @@
     local-name: geometry2/tf2_msgs
     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_msgs/0.5.18-0.tar.gz
     version: geometry2-release-release-kinetic-tf2_msgs-0.5.18-0
-# Python based package, not needed
-# - tar:
-#     local-name: geometry2/tf2_py
-#     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_py/0.5.18-0.tar.gz
-#     version: geometry2-release-release-kinetic-tf2_py-0.5.18-0
+- tar:
+    local-name: geometry2/tf2_py
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_py/0.5.18-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2_py-0.5.18-0
 - tar:
     local-name: geometry2/tf2_ros
     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_ros/0.5.18-0.tar.gz
@@ -450,11 +448,10 @@
     local-name: orocos_kinematics_dynamics/orocos_kdl
     uri: https://github.com/smits/orocos-kdl-release/archive/release/kinetic/orocos_kdl/1.3.1-0.tar.gz
     version: orocos-kdl-release-release-kinetic-orocos_kdl-1.3.1-0
-# Python based package, not needed
-# - tar:
-#     local-name: orocos_kinematics_dynamics/python_orocos_kdl
-#     uri: https://github.com/smits/orocos-kdl-release/archive/release/kinetic/python_orocos_kdl/1.3.1-0.tar.gz
-#     version: orocos-kdl-release-release-kinetic-python_orocos_kdl-1.3.1-0
+- tar:
+    local-name: orocos_kinematics_dynamics/python_orocos_kdl
+    uri: https://github.com/smits/orocos-kdl-release/archive/release/kinetic/python_orocos_kdl/1.3.1-0.tar.gz
+    version: orocos-kdl-release-release-kinetic-python_orocos_kdl-1.3.1-0
 - tar:
     local-name: pcl_conversions
     uri: https://github.com/ros-gbp/pcl_conversions-release/archive/release/kinetic/pcl_conversions/0.2.1-0.tar.gz
@@ -475,11 +472,10 @@
     local-name: pluginlib
     uri: https://github.com/ros-gbp/pluginlib-release/archive/release/kinetic/pluginlib/1.11.3-0.tar.gz
     version: pluginlib-release-release-kinetic-pluginlib-1.11.3-0
-# Python based package, not needed
-# - tar:
-#     local-name: python_qt_binding
-#     uri: https://github.com/ros-gbp/python_qt_binding-release/archive/release/kinetic/python_qt_binding/0.3.4-0.tar.gz
-#     version: python_qt_binding-release-release-kinetic-python_qt_binding-0.3.4-0
+- tar:
+    local-name: python_qt_binding
+    uri: https://github.com/ros-gbp/python_qt_binding-release/archive/release/kinetic/python_qt_binding/0.3.4-0.tar.gz
+    version: python_qt_binding-release-release-kinetic-python_qt_binding-0.3.4-0
 - tar:
     local-name: random_numbers
     uri: https://github.com/ros-gbp/random_numbers-release/archive/release/kinetic/random_numbers/0.3.1-0.tar.gz
@@ -506,26 +502,23 @@
 #     local-name: ros/ros
 #     uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/ros/1.14.4-0.tar.gz
 #     version: ros-release-release-kinetic-ros-1.14.4-0
-# Only bash scripts, not needed.
-# - tar:
-#     local-name: ros/rosbash
-#     uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/rosbash/1.14.4-0.tar.gz
-#     version: ros-release-release-kinetic-rosbash-1.14.4-0
+- tar:
+    local-name: ros/rosbash
+    uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/rosbash/1.14.4-0.tar.gz
+    version: ros-release-release-kinetic-rosbash-1.14.4-0
 # Scripts only, not needed.
 # - tar:
 #     local-name: ros/rosboost_cfg
 #     uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/rosboost_cfg/1.14.4-0.tar.gz
 #     version: ros-release-release-kinetic-rosboost_cfg-1.14.4-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros/rosbuild
-#     uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/rosbuild/1.14.4-0.tar.gz
-#     version: ros-release-release-kinetic-rosbuild-1.14.4-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros/rosclean
-#     uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/rosclean/1.14.4-0.tar.gz
-#     version: ros-release-release-kinetic-rosclean-1.14.4-0
+- tar:
+    local-name: ros/rosbuild
+    uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/rosbuild/1.14.4-0.tar.gz
+    version: ros-release-release-kinetic-rosbuild-1.14.4-0
+- tar:
+    local-name: ros/rosclean
+    uri: https://github.com/ros-gbp/ros-release/archive/release/kinetic/rosclean/1.14.4-0.tar.gz
+    version: ros-release-release-kinetic-rosclean-1.14.4-0
 # Scripts only, not needed.
 # - tar:
 #     local-name: ros/roscreate
@@ -574,70 +567,58 @@
     local-name: ros_comm/roscpp
     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roscpp/1.12.14-0.tar.gz
     version: ros_comm-release-release-kinetic-roscpp-1.12.14-0
-# Scripts only, needed by tf2_ros.
 - tar:
     local-name: ros_comm/rosgraph
     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosgraph/1.12.14-0.tar.gz
     version: ros_comm-release-release-kinetic-rosgraph-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/roslaunch
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-roslaunch-1.12.14-0
+- tar:
+    local-name: ros_comm/roslaunch
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-roslaunch-1.12.14-0
 - tar:
     local-name: ros_comm/roslz4
     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslz4/1.12.14-0.tar.gz
     version: ros_comm-release-release-kinetic-roslz4-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/rosmaster
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-rosmaster-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/rosmsg
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-rosmsg-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/rosnode
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-rosnode-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/rosout
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-rosout-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/rosparam
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-rosparam-1.12.14-0
-# Python package, but needed by diagnostics.
+- tar:
+    local-name: ros_comm/rosmaster
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-rosmaster-1.12.14-0
+- tar:
+    local-name: ros_comm/rosmsg
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-rosmsg-1.12.14-0
+- tar:
+    local-name: ros_comm/rosnode
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-rosnode-1.12.14-0
+- tar:
+    local-name: ros_comm/rosout
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-rosout-1.12.14-0
+- tar:
+    local-name: ros_comm/rosparam
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-rosparam-1.12.14-0
 - tar:
     local-name: ros_comm/rospy
     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rospy/1.12.14-0.tar.gz
     version: ros_comm-release-release-kinetic-rospy-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/rosservice
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-rosservice-1.12.14-0
-# Scripts only, but needed by self_test.
+- tar:
+    local-name: ros_comm/rosservice
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-rosservice-1.12.14-0
 - tar:
     local-name: ros_comm/rostest
     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostest/1.12.14-0.tar.gz
     version: ros_comm-release-release-kinetic-rostest-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/rostopic
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-rostopic-1.12.14-0
-# Scripts only, not needed.
-# - tar:
-#     local-name: ros_comm/roswtf
-#     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.14-0.tar.gz
-#     version: ros_comm-release-release-kinetic-roswtf-1.12.14-0
+- tar:
+    local-name: ros_comm/rostopic
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-rostopic-1.12.14-0
+- tar:
+    local-name: ros_comm/roswtf
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.14-0.tar.gz
+    version: ros_comm-release-release-kinetic-roswtf-1.12.14-0
 - tar:
     local-name: ros_comm/topic_tools
     uri: https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/topic_tools/1.12.14-0.tar.gz
@@ -690,12 +671,11 @@
     local-name: roslint
     uri: https://github.com/ros-gbp/roslint-release/archive/release/kinetic/roslint/0.11.0-0.tar.gz
     version: roslint-release-release-kinetic-roslint-0.11.0-0
-# Scripts only, not needed.
+# Roslisp is a client library for writing ROS nodes in idiomatic Common Lisp. -> not needed
 # - tar:
 #     local-name: roslisp
 #     uri: https://github.com/ros-gbp/roslisp-release/archive/release/kinetic/roslisp/1.9.21-0.tar.gz
 #     version: roslisp-release-release-kinetic-roslisp-1.9.21-0
-# Needed by roslib.
 - tar:
     local-name: rospack
     uri: https://github.com/ros-gbp/rospack-release/archive/release/kinetic/rospack/2.4.4-0.tar.gz
@@ -724,8 +704,6 @@
     local-name: vision_opencv/vision_opencv
     uri: https://github.com/ros-gbp/vision_opencv-release/archive/release/kinetic/vision_opencv/1.12.8-0.tar.gz
     version: vision_opencv-release-release-kinetic-vision_opencv-1.12.8-0
-# Python based package, not needed.
-# - tar:
-#     local-name: xacro
-#     uri: https://github.com/ros-gbp/xacro-release/archive/release/kinetic/xacro/1.11.3-0.tar.gz
-#     version: xacro-release-release-kinetic-xacro-1.11.3-0
+    local-name: xacro
+    uri: https://github.com/ros-gbp/xacro-release/archive/release/kinetic/xacro/1.11.3-0.tar.gz
+    version: xacro-release-release-kinetic-xacro-1.11.3-0

--- a/ros.rosinstall
+++ b/ros.rosinstall
@@ -198,7 +198,7 @@
 - tar:
     local-name: geometry2/tf2
     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2-0.5.18-0
+    version: geometry2-release-release-kinetic-tf2
 - tar:
     local-name: geometry2/tf2_eigen
     uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_eigen/0.5.18-0.tar.gz

--- a/ros.rosinstall
+++ b/ros.rosinstall
@@ -704,6 +704,7 @@
     local-name: vision_opencv/vision_opencv
     uri: https://github.com/ros-gbp/vision_opencv-release/archive/release/kinetic/vision_opencv/1.12.8-0.tar.gz
     version: vision_opencv-release-release-kinetic-vision_opencv-1.12.8-0
+- tar:
     local-name: xacro
     uri: https://github.com/ros-gbp/xacro-release/archive/release/kinetic/xacro/1.11.3-0.tar.gz
     version: xacro-release-release-kinetic-xacro-1.11.3-0


### PR DESCRIPTION
Some plugins from a custom workspace were missing (using `--extend-workspace` from #73). Packages providing plugins only need to depend on the package that provides the base class, but not necessarily on `pluginlib` directly.

`plugin_collect.py` only finds **direct** dependencies of `pluginlib`, `nodelet` or `image_transport_plugins`. For example, packages that provide plugins for `filters` and which do not additionally depend on `pluginlib` were not considered. The solution is actually trivial because [RosPack.get_depends_on](http://docs.ros.org/independent/api/rospkg/html/rospkg_packages.html#rospkg.RosPack.get_depends_on) already has a flag to search recursively, but it silently(!) discarded other packages again because the set of packages in the `catkin_ws` was not consistent. This might be related to https://github.com/ros-infrastructure/rospkg/issues/142, without having had a closer look.

https://github.com/Intermodalics/ros_android/commit/a121628ca059bee3f107263ec20989d0ce081c71 fixes the problem by uncommenting most of the Python-based packages commented in #63 and older commits. They are not required by themselves, but satisfy dependencies of other packages in the workspace. Independent of that, I think that some of the disabled packages might still be useful for downstream packages even though they will only be used at build-time and additional build time is negligible. So readding them is not the worst thing. Sorry for [revising my opinion](https://github.com/Intermodalics/ros_android/pull/63#issuecomment-446138504) on that.

Fixes https://github.com/Intermodalics/ros_android/issues/93.

