### PR TITLE
patches: fixed linking to SDL library in map_server

### DIFF
--- a/patches/map_server.patch
+++ b/patches/map_server.patch
@@ -1,6 +1,6 @@
 --- catkin_ws/src/navigation/map_server/CMakeLists.txt
 +++ catkin_ws/src/navigation/map_server/CMakeLists.txt
-@@ -12,10 +12,17 @@ find_package(Bullet REQUIRED)
+@@ -12,17 +12,31 @@ find_package(Bullet REQUIRED)
  find_package(SDL REQUIRED)
  find_package(SDL_image REQUIRED)
  
@@ -21,19 +21,21 @@
  endif()
  
  catkin_package(
-@@ -23,6 +30,11 @@ catkin_package(
+     INCLUDE_DIRS
          include
++        ${SDL_INCLUDE_DIR}
      LIBRARIES
          map_server_image_loader
++        ${SDL_LIBRARY}
 +    DEPENDS
 +        BULLET
-+        SDL
++        #SDL         # <-- Does not work because SDL_INCLUDE_DIRS and SDL_LIBRARIES is not set.
 +        SDL_IMAGE
 +        YAML_CPP
      CATKIN_DEPENDS
          roscpp
          nav_msgs
-@@ -35,7 +47,7 @@ include_directories(
+@@ -35,7 +49,7 @@ include_directories(
      ${catkin_INCLUDE_DIRS}
      ${SDL_INCLUDE_DIR}
      ${SDL_IMAGE_INCLUDE_DIRS}
@@ -42,7 +44,7 @@
  )
  
  add_library(map_server_image_loader src/image_loader.cpp)
-@@ -51,7 +63,7 @@ add_executable(map_server src/main.cpp)
+@@ -51,7 +65,7 @@ add_executable(map_server src/main.cpp)
  add_dependencies(map_server ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
  target_link_libraries(map_server
      map_server_image_loader


### PR DESCRIPTION
Fixes linking to `libSDLmain.a` and `libSDL.a` in downstream packages.

```cmake
find_package(SDL REQUIRED)
```

(with [FindSDL.cmake](https://github.com/Kitware/CMake/blob/master/Modules/FindSDL.cmake) provided by cmake) only sets `SDL_LIBRARY` and `SDL_INCLUDE_DIR` (without the trailing `S`). But `catkin_package(DEPENDS <prefix>)` looks for `<prefix>_INCLUDE_DIRS` and `<prefix>_LIBRARIES`. `catkin` emits a warning if neither of both is set for a dependency listed in `DEPENDS`, which should actually be treated as an error. Or `catkin` could accept multiple commonly used suffixes for include directories and libraries because apparently there is no standard. See related issue https://github.com/ros/catkin/issues/552.

In any case listing `SDL` in `catkin_package(DEPS ...)` is equivalent to listing include directories and libraries in `INCLUDE_DIRS` and `LIBRARIES` argument lists.

Another candidate to submit a patch upstream (#81).