### PR TITLE
Patch image_proc to export all of its catkin dependencies

### DIFF
--- a/patches/image_proc.patch
+++ b/patches/image_proc.patch
@@ -1,0 +1,12 @@
+--- catkin_ws/src/image_pipeline/image_proc/CMakeLists.txt
++++ catkin_ws/src/image_pipeline/image_proc/CMakeLists.txt
+@@ -15,7 +15,7 @@ endif()
+ generate_dynamic_reconfigure_options(cfg/CropDecimate.cfg cfg/Debayer.cfg cfg/Rectify.cfg cfg/Resize.cfg)
+ 
+ catkin_package(
+-  CATKIN_DEPENDS image_geometry roscpp sensor_msgs
++  CATKIN_DEPENDS cv_bridge dynamic_reconfigure image_geometry image_transport nodelet nodelet_topic_tools roscpp sensor_msgs
+   DEPENDS OpenCV
+   INCLUDE_DIRS include
+   LIBRARIES ${PROJECT_NAME}
+


### PR DESCRIPTION
The exported library image_proc depends on most of the found catkin packages, so for static builds they must be exported in `catkin_package(LIBRARIES ...)`. Otherwise downstream packages fail to link against `image_proc` because of missing symbols.