### PR TITLE
Updating ROS kinetic packages to latest versions.

### DIFF
--- a/ros.rosinstall
+++ b/ros.rosinstall
@@ -52,44 +52,44 @@
 #     version: collada_urdf-release-release-kinetic-collada_urdf-1.12.12-0
 - tar:
     local-name: common_msgs/actionlib_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/actionlib_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-actionlib_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/actionlib_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-actionlib_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/common_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/common_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-common_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/common_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-common_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/diagnostic_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/diagnostic_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-diagnostic_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/diagnostic_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-diagnostic_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/geometry_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/geometry_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-geometry_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/geometry_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-geometry_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/nav_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/nav_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-nav_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/nav_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-nav_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/sensor_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/sensor_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-sensor_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/sensor_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-sensor_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/shape_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/shape_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-shape_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/shape_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-shape_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/stereo_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/stereo_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-stereo_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/stereo_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-stereo_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/trajectory_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/trajectory_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-trajectory_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/trajectory_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-trajectory_msgs-1.12.7-0
 - tar:
     local-name: common_msgs/visualization_msgs
-    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/visualization_msgs/1.12.6-0.tar.gz
-    version: common_msgs-release-release-kinetic-visualization_msgs-1.12.6-0
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/visualization_msgs/1.12.7-0.tar.gz
+    version: common_msgs-release-release-kinetic-visualization_msgs-1.12.7-0
 - tar:
     local-name: control_msgs
     uri: https://github.com/ros-gbp/control_msgs-release/archive/release/kinetic/control_msgs/1.4.0-0.tar.gz
@@ -197,32 +197,32 @@
     version: geometry-release-release-kinetic-tf_conversions-1.11.9-0
 - tar:
     local-name: geometry2/tf2
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2/0.5.20-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2-0.5.20-0
 - tar:
     local-name: geometry2/tf2_eigen
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_eigen/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2_eigen-0.5.18-0
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_eigen/0.5.20-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2_eigen-0.5.20-0
 - tar:
     local-name: geometry2/tf2_geometry_msgs
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_geometry_msgs/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2_geometry_msgs-0.5.18-0
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_geometry_msgs/0.5.20-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2_geometry_msgs-0.5.20-0
 - tar:
     local-name: geometry2/tf2_kdl
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_kdl/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2_kdl-0.5.18-0
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_kdl/0.5.20-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2_kdl-0.5.20-0
 - tar:
     local-name: geometry2/tf2_msgs
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_msgs/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2_msgs-0.5.18-0
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_msgs/0.5.20-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2_msgs-0.5.20-0
 - tar:
     local-name: geometry2/tf2_py
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_py/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2_py-0.5.18-0
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_py/0.5.20-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2_py-0.5.20-0
 - tar:
     local-name: geometry2/tf2_ros
-    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_ros/0.5.18-0.tar.gz
-    version: geometry2-release-release-kinetic-tf2_ros-0.5.18-0
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/kinetic/tf2_ros/0.5.20-0.tar.gz
+    version: geometry2-release-release-kinetic-tf2_ros-0.5.20-0
 - tar:
     local-name: image_common/camera_calibration_parsers
     uri: https://github.com/ros-gbp/image_common-release/archive/release/kinetic/camera_calibration_parsers/1.11.13-0.tar.gz
@@ -667,6 +667,10 @@
     local-name: roscpp_core/rostime
     uri: https://github.com/ros-gbp/roscpp_core-release/archive/release/kinetic/rostime/0.6.11-0.tar.gz
     version: roscpp_core-release-release-kinetic-rostime-0.6.11-0
+- tar:
+    local-name: rosjava_build_tools
+    uri: https://github.com/rosjava-release/rosjava_build_tools-release/archive/release/kinetic/rosjava_build_tools/0.3.3-1.tar.gz
+    version: rosjava_build_tools-release-release-kinetic-rosjava_build_tools-0.3.3-1
 - tar:
     local-name: roslint
     uri: https://github.com/ros-gbp/roslint-release/archive/release/kinetic/roslint/0.11.0-0.tar.gz


### PR DESCRIPTION
- `common_msgs-1.12.6` --> `common_msgs-1.12.7`.
- `geometry2-0.5.18` --> `geometry2-0.5.20`.
- Adding `rosjava_build_tools` with proper version (needed by #84).