### PR TITLE
Changed from wstool merging to soft linking ros.rosinstall

### DIFF
--- a/scripts/get_catkin_packages.sh
+++ b/scripts/get_catkin_packages.sh
@@ -25,11 +25,10 @@ prefix=$(cd $2 && pwd)
 cd $prefix
 mkdir -p catkin_ws/src && cd catkin_ws
 
-if [ -f src/.rosinstall ]; then
-  cd src/
-  wstool merge $rosinstall_file --merge-replace
-  wstool update
-  cd ..
-else
-  wstool init -j$PARALLEL_JOBS src $rosinstall_file
+if [ ! -f src/.rosinstall ]; then
+  ln -s $rosinstall_file src/.rosinstall
 fi
+
+cd src/
+wstool update -j$PARALLEL_JOBS
+cd ..

--- a/scripts/get_catkin_packages.sh
+++ b/scripts/get_catkin_packages.sh
@@ -25,10 +25,9 @@ prefix=$(cd $2 && pwd)
 cd $prefix
 mkdir -p catkin_ws/src && cd catkin_ws
 
-if [ ! -f src/.rosinstall ]; then
-  ln -s $rosinstall_file src/.rosinstall
+pushd src
+if [ ! -f .rosinstall ]; then
+  ln -s $rosinstall_file .rosinstall
 fi
-
-cd src/
 wstool update -j$PARALLEL_JOBS
-cd ..
+popd

--- a/scripts/get_system_dependencies.sh
+++ b/scripts/get_system_dependencies.sh
@@ -27,15 +27,13 @@ rosinstall_file="$1"
 lib_prefix=$(cd "$2" && pwd)
 files_prefix=$(cd "$3" && pwd)
 
-# Get everything
-if [ -f $lib_prefix/.rosinstall ]; then
-  pushd $lib_prefix
-  wstool merge $rosinstall_file --merge-replace
-  wstool update -j$PARALLEL_JOBS
-  popd
-else
-  wstool init -j$PARALLEL_JOBS $lib_prefix $rosinstall_file
+
+pushd $lib_prefix
+if [ ! -f .rosinstall ]; then
+  ln -s $rosinstall_file .rosinstall
 fi
+wstool update -j$PARALLEL_JOBS
+popd
 
 # Library-specific patches / actions.
 


### PR DESCRIPTION
This is an old @meyerj proposal. Basically, if something is deleted of the ros.rosinstall list, wstool merging doesn't help. Soft linking it's a better option to avoid manually deleting the .rosinstall file in catkin_ws/src

I will also apply this tomorrow for downloading libraries.