### PR TITLE
cv_bridge: replace imported library targets by the full path to OpenCV_LIBRARIES

### DIFF
--- a/patches/cv_bridge.patch
+++ b/patches/cv_bridge.patch
@@ -10,7 +10,7 @@
  
 --- catkin_ws/src/vision_opencv/cv_bridge/cmake/cv_bridge-extras.cmake.in
 +++ catkin_ws/src/vision_opencv/cv_bridge/cmake/cv_bridge-extras.cmake.in
-@@ -1,12 +1,14 @@
+@@ -1,12 +1,22 @@
 -set(OpenCV_VERSION @OpenCV_VERSION@)
 -set(OpenCV_VERSION_MAJOR @OpenCV_VERSION_MAJOR@)
 -set(OpenCV_VERSION_MINOR @OpenCV_VERSION_MINOR@)
@@ -32,5 +32,13 @@
 +# replace imported targets to mimic the behavior of catkin_package(LIBRARIES)
 +catkin_replace_imported_library_targets(OpenCV_LIBRARIES ${OpenCV_LIBRARIES})
 +
-+list(APPEND @PROJECT_NAME@_LIBRARIES ${OpenCV_LIBRARIES})
-+list(APPEND @PROJECT_NAME@_INCLUDE_DIRS ${OpenCV_INCLUDE_DIRS})
++# deduplicate libraries while maintaining build configuration keywords
++catkin_pack_libraries_with_build_configuration(_@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_LIBRARIES} ${OpenCV_LIBRARIES})
++set(@PROJECT_NAME@_LIBRARIES "")
++foreach(library ${_@PROJECT_NAME@_LIBRARIES})
++  list_append_deduplicate(@PROJECT_NAME@_LIBRARIES ${library})
++endforeach()
++catkin_unpack_libraries_with_build_configuration(@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
++unset(_@PROJECT_NAME@_LIBRARIES)
++
++list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${OpenCV_INCLUDE_DIRS})

--- a/patches/cv_bridge.patch
+++ b/patches/cv_bridge.patch
@@ -10,7 +10,7 @@
  
 --- catkin_ws/src/vision_opencv/cv_bridge/cmake/cv_bridge-extras.cmake.in
 +++ catkin_ws/src/vision_opencv/cv_bridge/cmake/cv_bridge-extras.cmake.in
-@@ -1,11 +1,10 @@
+@@ -1,12 +1,14 @@
 -set(OpenCV_VERSION @OpenCV_VERSION@)
 -set(OpenCV_VERSION_MAJOR @OpenCV_VERSION_MAJOR@)
 -set(OpenCV_VERSION_MINOR @OpenCV_VERSION_MINOR@)
@@ -21,7 +21,6 @@
 -set(OpenCV_LIB_COMPONENTS @OpenCV_LIB_COMPONENTS@)
 -set(OpenCV_USE_MANGLED_PATHS @OpenCV_USE_MANGLED_PATHS@)
 -set(OpenCV_MODULES_SUFFIX @OpenCV_MODULES_SUFFIX@)
--
 +find_package(OpenCV 3 REQUIRED
 +  COMPONENTS
 +    opencv_core
@@ -29,6 +28,9 @@
 +    opencv_imgcodecs
 +  CONFIG
 +)
+ 
++# replace imported targets to mimic the behavior of catkin_package(LIBRARIES)
++catkin_replace_imported_library_targets(OpenCV_LIBRARIES ${OpenCV_LIBRARIES})
 +
 +list(APPEND @PROJECT_NAME@_LIBRARIES ${OpenCV_LIBRARIES})
 +list(APPEND @PROJECT_NAME@_INCLUDE_DIRS ${OpenCV_INCLUDE_DIRS})


### PR DESCRIPTION
catkin does replace exported libraries that are imported targets (like `opencv_core`, `opencv_imgproc` and `opencv_imgcodecs`) by the full paths to these libraries in [catkin_libraries.cmake:258](https://github.com/ros/catkin/blob/4812667954e4cb7f99a753ffd4d725047e73a73b/cmake/catkin_package.cmake#L258), with subsequent deduplication.

If we add the OpenCV imported targets directly in `cv_bridge-extras.cmake.in`, deduplication does not work and derived packages end up with both, the full path and the target in `<pkg>_LIBRARIES` and `catkin_LIBRARIES`. There is no immediate problem with that, apart from the fact that it is not nice.

But in one case this caused a linker error in a non-catkin package that depends indirectly on `cv_bridge` and OpenCV, where the link directory was not set and the linker was failing due to not finding `-lopencv_core`, `-lopencv_imgproc` and `-lopencv_imgcodecs`.